### PR TITLE
Upload release artifacts when a tag is cut

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
         name: Create a GitHub release, if on tag.
         command: |
           if [[ -n "${CIRCLE_TAG}" ]]; then
-
+            ./scripts/create_github_release.sh "${CIRCLE_TAG}" ./bin
           fi
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,17 +57,16 @@ jobs:
     - run:
         name: Create a GitHub release, if on tag.
         command: |
-          if [[ -n "${CIRCLE_TAG}" ]]; then
-            wget --quiet https://github.com/gruntwork-io/fetch/releases/download/v0.3.5/fetch_linux_amd64
-            sudo install fetch_linux_amd64 /usr/bin/fetch
-            ghr_version="v0.13.0"
-            fetch --repo="https://github.com/tcnksm/ghr" --tag="${ghr_version}" --release-asset="ghr_${ghr_version}_linux_amd64.tar.gz" .
-            tar -zxvf ghr_${ghr_version}_linux_amd64.tar.gz
-            sudo install ghr_${ghr_version}_linux_amd64/ghr /usr/bin/ghr
-            which ghr
-            ./scripts/create_github_release.sh "${CIRCLE_TAG}" ./bin
-          fi
+          [[ -n "${CIRCLE_TAG}" ]] || exit 0
 
+          wget --quiet https://github.com/gruntwork-io/fetch/releases/download/v0.3.5/fetch_linux_amd64
+          sudo install fetch_linux_amd64 /usr/bin/fetch
+          ghr_version="v0.13.0"
+          fetch --repo="https://github.com/tcnksm/ghr" --tag="${ghr_version}" --release-asset="ghr_${ghr_version}_linux_amd64.tar.gz" .
+          tar -zxvf ghr_${ghr_version}_linux_amd64.tar.gz
+          sudo install ghr_${ghr_version}_linux_amd64/ghr /usr/bin/ghr
+          which ghr
+          ./scripts/create_github_release.sh "${CIRCLE_TAG}" ./bin
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
             ghr_version="v0.13.0"
             fetch --repo="https://github.com/tcnksm/ghr" --tag="${ghr_version}" --release-asset="ghr_${ghr_version}_linux_amd64.tar.gz" .
             tar -zxvf ghr_${ghr_version}_linux_amd64.tar.gz
-            sudo install ghr_${ghr_version}_linux_amd64 /usr/bin/ghr
+            sudo install ghr_${ghr_version}_linux_amd64/ghr /usr/bin/ghr
             which ghr
             ./scripts/create_github_release.sh "${CIRCLE_TAG}" ./bin
           fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,13 @@ jobs:
           echo "Version from kube-linter: ${version}. Expected version: ${expected_version}"
           [[ "${version}" == "${expected_version}" ]]
 
+    - run:
+        name: Create a GitHub release, if on tag.
+        command: |
+          if [[ -n "${CIRCLE_TAG}" ]]; then
+
+          fi
+
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,13 @@ jobs:
         name: Create a GitHub release, if on tag.
         command: |
           if [[ -n "${CIRCLE_TAG}" ]]; then
+            wget --quiet https://github.com/gruntwork-io/fetch/releases/download/v0.3.5/fetch_linux_amd64
+            sudo install fetch_linux_amd64 /usr/bin/fetch
+            ghr_version="v0.13.0"
+            fetch --repo="https://github.com/tcnksm/ghr" --tag="${ghr_version}" --release-asset="ghr_${ghr_version}_linux_amd64.tar.gz" .
+            tar -zxvf ghr_${ghr_version}_linux_amd64.tar.gz
+            sudo install ghr_${ghr_version}_linux_amd64 /usr/bin/ghr
+            which ghr
             ./scripts/create_github_release.sh "${CIRCLE_TAG}" ./bin
           fi
 

--- a/scripts/create_github_release.sh
+++ b/scripts/create_github_release.sh
@@ -18,7 +18,7 @@ for os in darwin linux windows; do
     bin_name="kube-linter.exe"
   fi
   tar -C "${bin_dir}/${os}" -czf "${tmp_dir}/kube-linter-${os}.tar.gz" "${bin_name}"
-  zip "${tmp_dir}/kube-linter-${os}.zip" "${bin_dir}/${os}/${bin_name}"
+  zip --junk-paths "${tmp_dir}/kube-linter-${os}.zip" "${bin_dir}/${os}/${bin_name}"
 done
 
 ghr -prerelease -n "v${tag}" "${tag}" "${tmp_dir}"

--- a/scripts/create_github_release.sh
+++ b/scripts/create_github_release.sh
@@ -11,54 +11,10 @@ tag="$1"
 bin_dir="$2"
 [[ -n "${tag}" && -n "${bin_dir}" ]] || die "Usage: $0 <tag> <binary_directory>"
 
+mkdir /tmp/release-artifacts
+tar -czf /tmp/release-artifacts/kube-linter-darwin.tar.gz "${bin_dir}/darwin/kube-linter"
+tar -czf /tmp/release-artifacts/kube-linter-linux.tar.gz "${bin_dir}/linux/kube-linter"
+tar -czf /tmp/release-artifacts/kube-linter-windows.tar.gz "${bin_dir}/windows/kube-linter.exe"
 
-status_code=""
-curl_output=""
-
-# gh_curl makes an authenticated request to the GitHub API at the given subpath (with the common repo prefix automatically
-# added), and populates the results in the global status_code and curl_output variables.
-function gh_curl() {
-  local sub_path=$1
-  shift
-  curl -sS -w '%{http_code}' -o /tmp/curl.out -H "Authorization: Bearer ${GITHUB_TOKEN}" "https://api.github.com/repos/stackrox/kube-linter/${sub_path}" "$@" > /tmp/curl_status_code.out
-  status_code="$(cat /tmp/curl_status_code.out)"
-  curl_output="$(cat /tmp/curl.out)"
-  rm /tmp/curl_status_code.out /tmp/curl.out
-  einfo "Request to ${sub_path} with args \"$*\". Response code: ${status_code}"
-}
-
-einfo "Attempting to create release"
-gh_curl releases -X POST -d '{"tag_name": "'"${tag}"'", "name": "v'"${tag}"'", "prerelease": true}'
-if [[ "${status_code}" -eq 201 ]]; then
-  einfo "Successfully created release."
-elif [[ "${status_code}" -eq 422 ]]; then
-  ewarn "Release already exists; continuing."
-fi
-
-gh_curl "releases/tags/${tag}"
-if [[ "${status_code}" -ne 200 ]]; then
-  die "Unexpected status code from fetching the release: ${status_code}. Output: ${curl_output}"
-fi
-
-upload_url="$(jq -r '.upload_url' <<<"${curl_output}" | sed 's/{.*$//g')"
-einfo "Got upload_url: ${upload_url}"
-
-function upload_file() {
-  filename="$1"
-  basename="$(basename "${filename}")"
-  curl -H "Authorization: Bearer ${GITHUB_TOKEN}" "${upload_url}?name=${basename}" -X POST -F "file=@${filename}"
-  echo
-  rm "${filename}"
-}
-
-einfo "Uploading darwin binary..."
-tar -czf /tmp/kube-linter-darwin.tar.gz "${bin_dir}/darwin/kube-linter"
-upload_file /tmp/kube-linter-darwin.tar.gz
-
-einfo "Uploading linux binary..."
-tar -czf /tmp/kube-linter-linux.tar.gz "${bin_dir}/linux/kube-linter"
-upload_file /tmp/kube-linter-linux.tar.gz
-
-einfo "Uploading windows binary..."
-tar -czf /tmp/kube-linter-windows.tar.gz "${bin_dir}/windows/kube-linter.exe"
-upload_file /tmp/kube-linter-windows.tar.gz
+ghr -prerelease -n "v${tag}" "${tag}" /tmp/release-artifacts
+rm -r /tmp/release-artifacts

--- a/scripts/create_github_release.sh
+++ b/scripts/create_github_release.sh
@@ -11,14 +11,15 @@ tag="$1"
 bin_dir="$2"
 [[ -n "${tag}" && -n "${bin_dir}" ]] || die "Usage: $0 <tag> <binary_directory>"
 
-mkdir /tmp/release-artifacts
+tmp_dir="$(mktemp -d)"
 for os in darwin linux windows; do
   bin_name="kube-linter"
   if [[ "${os}" == "windows" ]]; then
     bin_name="kube-linter.exe"
   fi
-  tar -C "${bin_dir}/${os}" -czf "/tmp/release-artifacts/kube-linter-${os}.tar.gz" "${bin_name}"
+  tar -C "${bin_dir}/${os}" -czf "${tmp_dir}/kube-linter-${os}.tar.gz" "${bin_name}"
+  zip "${tmp_dir}/kube-linter-${os}.zip" "${bin_dir}/${os}/${bin_name}"
 done
 
-ghr -prerelease -n "v${tag}" "${tag}" /tmp/release-artifacts
-rm -r /tmp/release-artifacts
+ghr -prerelease -n "v${tag}" "${tag}" "${tmp_dir}"
+rm -rf "${tmp_dir}"

--- a/scripts/create_github_release.sh
+++ b/scripts/create_github_release.sh
@@ -12,9 +12,13 @@ bin_dir="$2"
 [[ -n "${tag}" && -n "${bin_dir}" ]] || die "Usage: $0 <tag> <binary_directory>"
 
 mkdir /tmp/release-artifacts
-tar -czf /tmp/release-artifacts/kube-linter-darwin.tar.gz "${bin_dir}/darwin/kube-linter"
-tar -czf /tmp/release-artifacts/kube-linter-linux.tar.gz "${bin_dir}/linux/kube-linter"
-tar -czf /tmp/release-artifacts/kube-linter-windows.tar.gz "${bin_dir}/windows/kube-linter.exe"
+for os in darwin linux windows; do
+  bin_name="kube-linter"
+  if [[ "${os}" == "windows" ]]; then
+    bin_name="kube-linter.exe"
+  fi
+  tar -C "${bin_dir}/${os}" -czf "/tmp/release-artifacts/kube-linter-${os}.tar.gz" "${bin_name}"
+done
 
 ghr -prerelease -n "v${tag}" "${tag}" /tmp/release-artifacts
 rm -r /tmp/release-artifacts

--- a/scripts/create_github_release.sh
+++ b/scripts/create_github_release.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/utils.sh"
+
+set -eo pipefail
+
+[[ -n "${GITHUB_TOKEN}" ]] || die "No GITHUB_TOKEN found."
+
+tag="$1"
+bin_dir="$2"
+[[ -n "${tag}" && -n "${bin_dir}" ]] || die "Usage: $0 <tag> <binary_directory>"
+
+
+status_code=""
+curl_output=""
+
+# gh_curl makes an authenticated request to the GitHub API at the given subpath (with the common repo prefix automatically
+# added), and populates the results in the global status_code and curl_output variables.
+function gh_curl() {
+  local sub_path=$1
+  shift
+  curl -sS -w '%{http_code}' -o /tmp/curl.out -H "Authorization: Bearer ${GITHUB_TOKEN}" "https://api.github.com/repos/stackrox/kube-linter/${sub_path}" "$@" > /tmp/curl_status_code.out
+  status_code="$(cat /tmp/curl_status_code.out)"
+  curl_output="$(cat /tmp/curl.out)"
+  rm /tmp/curl_status_code.out /tmp/curl.out
+  einfo "Request to ${sub_path} with args \"$*\". Response code: ${status_code}"
+}
+
+einfo "Attempting to create release"
+gh_curl releases -X POST -d '{"tag_name": "'"${tag}"'", "name": "v'"${tag}"'", "prerelease": true}'
+if [[ "${status_code}" -eq 201 ]]; then
+  einfo "Successfully created release."
+elif [[ "${status_code}" -eq 422 ]]; then
+  ewarn "Release already exists; continuing."
+fi
+
+gh_curl "releases/tags/${tag}"
+if [[ "${status_code}" -ne 200 ]]; then
+  die "Unexpected status code from fetching the release: ${status_code}. Output: ${curl_output}"
+fi
+
+upload_url="$(jq -r '.upload_url' <<<"${curl_output}" | sed 's/{.*$//g')"
+einfo "Got upload_url: ${upload_url}"
+
+function upload_file() {
+  filename="$1"
+  basename="$(basename "${filename}")"
+  curl -H "Authorization: Bearer ${GITHUB_TOKEN}" "${upload_url}?name=${basename}" -X POST -F "file=@${filename}"
+  echo
+  rm "${filename}"
+}
+
+einfo "Uploading darwin binary..."
+tar -czf /tmp/kube-linter-darwin.tar.gz "${bin_dir}/darwin/kube-linter"
+upload_file /tmp/kube-linter-darwin.tar.gz
+
+einfo "Uploading linux binary..."
+tar -czf /tmp/kube-linter-linux.tar.gz "${bin_dir}/linux/kube-linter"
+upload_file /tmp/kube-linter-linux.tar.gz
+
+einfo "Uploading windows binary..."
+tar -czf /tmp/kube-linter-windows.tar.gz "${bin_dir}/windows/kube-linter.exe"
+upload_file /tmp/kube-linter-windows.tar.gz


### PR DESCRIPTION
Use the GitHub API to automatically create a release, and upload the binaries to it, whenever a tag is cut. The release will be marked as a pre-release; a human needs to go in and verify that all is well before promoting it.