### PR TITLE
Update ignore annotation format

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,7 @@ are configured, and add them to the config file. The built-in checks are specifi
 ### Ignoring violations for specific cases
 
 To ignore violations for specific objects, users can add an annotation with the key
-`kube-linter.io/ignore/<check-name>`. We strongly encourage adding an explanation as the value for the annotation.
+`ignore-check.kube-linter.io/<check-name>`. We strongly encourage adding an explanation as the value for the annotation.
 For example, to ignore a check named "privileged" for a specific deployment, you can add an annotation like:
 `kube-linter.io/ignore/privileged: "This deployment needs to run as privileged because it needs kernel access"`.
 

--- a/internal/ignore/ignore.go
+++ b/internal/ignore/ignore.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	// AnnotationKeyPrefix is the prefix for annotations for kube-linter check ignores.
-	AnnotationKeyPrefix = "kube-linter.io/ignore/"
+	AnnotationKeyPrefix = "ignore-check.kube-linter.io/"
 
 	// AllAnnotationKey is used to ignore all checks for a given object.
 	AllAnnotationKey = "kube-linter.io/ignore-all"

--- a/internal/ignore/ignore_test.go
+++ b/internal/ignore/ignore_test.go
@@ -23,31 +23,31 @@ func TestObjectForCheck(t *testing.T) {
 		},
 		{
 			annotations: map[string]string{
-				"random-unrelated":                 "blah",
-				"kube-linter.io/ignore/some-check": "Not applicable",
+				"random-unrelated":                       "blah",
+				"ignore-check.kube-linter.io/some-check": "Not applicable",
 			},
 			checkName:    "some-check",
 			shouldIgnore: true,
 		},
 		{
 			annotations: map[string]string{
-				"random-unrelated":                 "blah",
-				"kube-linter.io/ignore/some-check": "Not applicable",
+				"random-unrelated":                       "blah",
+				"ignore-check.kube-linter.io/some-check": "Not applicable",
 			},
 			checkName: "some-check-2",
 		},
 		{
 			annotations: map[string]string{
-				"random-unrelated":                 "blah",
-				"kube-linter.io/ignore/some-check": "Not applicable",
+				"random-unrelated":                       "blah",
+				"ignore-check.kube-linter.io/some-check": "Not applicable",
 			},
 			checkName: "other-check",
 		},
 		{
 			annotations: map[string]string{
-				"random-unrelated":                  "blah",
-				"kube-linter.io/ignore/some-check":  "Not applicable",
-				"kube-linter.io/ignore/other-check": "Not applicable",
+				"random-unrelated":                        "blah",
+				"ignore-check.kube-linter.io/some-check":  "Not applicable",
+				"ignore-check.kube-linter.io/other-check": "Not applicable",
 			},
 			checkName:    "other-check",
 			shouldIgnore: true,


### PR DESCRIPTION
It turns out that Kubernetes doesn't support multiple slashes in annotation keys, so the old ignore check annotations did not work -- the objects didn't pass API server validation. Fix by changing the format of the key.

Soon, we should add a check to make sure the objects pass API server validation. Feels like pretty basic functionality for `kube-linter`.