### PR TITLE
Add installation instruction for Homebrew and Linuxbrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Otherwise, download the latest binary from
 [Releases](https://github.com/stackrox/kube-linter/releases) and add it to your
 PATH.
 
+### Via Homebrew for macOS or LinuxBrew for Linux
+
+```bash
+brew install kube-linter
+```
+
 ### Building from source
 
 > **NOTE**: Before you build, make sure that you have [installed


### PR DESCRIPTION
Congratulations dear Stackrox-team 🥳 ,
`kube-linter` has been added to [Homebrew-core](https://github.com/Homebrew/homebrew-core/pull/64408) and will soon also be added to Linuxbrew (automatically).

This means that it can be installed via `brew install kube-linter` on macOS.
The Homebrew-community will take care of updating the formula and keep it working (even on the new Apple Silicon). To create a Pull Request automatically when you create a new release you can use this GitHub action for example https://github.com/marketplace/actions/bump-homebrew-formula.

With `brew info kube-linter` you can also get how many times the formula was installed within the last 30, 90 and 365 days.

If you have any further questions feel free to @ me.

@SimonBaeumer regarding your question about adding the formula to `homebrew-cask` instead to prevent depending on `go` and `make`:
Casks are used for GUI applications.
All formulae in homebrew-core are built by the CI server which "bottles up" binaries for the 3 latest MacOS versions. The go and make dependencies only apply when you try to install a formula from the source (e.g. `brew install kube-linter --build-from-source`). Otherwise, they are simply pulled from bintray without requiring any dependency.
