### PR TITLE
Store built binaries as artifacts in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,9 @@ jobs:
           which ghr
           ./scripts/create_github_release.sh "${CIRCLE_TAG}" ./bin
 
+    - store_artifacts:
+        path: bin
+
 workflows:
   version: 2
   build:


### PR DESCRIPTION
This allows for easier testing on PRs.