### PR TITLE
Add sanity test to ensure KubeLinter doesn't crash on any charts from the Helm chart repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ executors:
   custom:
     docker:
       - image: cimg/go:1.15
-    working_directory: /kube-linter
+    working_directory: /home/circleci/kube-linter
 
 runOnAllTags: &runOnAllTags
   filters:
@@ -96,7 +96,7 @@ jobs:
         path: bin
 
     - persist_to_workspace:
-        root: /kube-linter
+        root: /home/circleci/kube-linter
         paths:
           - .gobin/kube-linter
 
@@ -105,7 +105,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: /kube-linter
+          at: /home/circleci/kube-linter
 
       - run:
           name: Run E2E tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ executors:
   custom:
     docker:
       - image: cimg/go:1.15
+    working_directory: /kube-linter
 
 runOnAllTags: &runOnAllTags
   filters:
@@ -94,6 +95,23 @@ jobs:
     - store_artifacts:
         path: bin
 
+    - persist_to_workspace:
+        root: /kube-linter
+        paths:
+          - .gobin/kube-linter
+
+  e2e-test:
+    executor: custom
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /kube-linter
+
+      - run:
+          name: Run E2E tests
+          command: |
+            make e2e-test
+
 workflows:
   version: 2
   build:
@@ -105,3 +123,7 @@ workflows:
     - build:
         <<: *runOnAllTags
         context: docker-io-push
+    - e2e-test:
+        <<: *runOnAllTags
+        requires:
+          - build

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ PATH := $(GOBIN):$(PATH)
 # See https://stackoverflow.com/a/36226784/3690207
 SHELL := env GOBIN=$(GOBIN) PATH=$(PATH) /bin/bash
 
+KUBE_LINTER_BIN := $(GOBIN)/kube-linter
+
 ########################################
 ###### Binaries we depend on ###########
 ########################################
@@ -102,6 +104,9 @@ build: packr
 	@cp "bin/$(HOST_OS)/kube-linter" "$(GOBIN)/kube-linter"
 	@chmod u+w "$(GOBIN)/kube-linter"
 
+$(KUBE_LINTER_BIN):
+	@$(MAKE) build
+
 .PHONY: image
 image: build
 	@cp bin/linux/kube-linter image/bin
@@ -113,4 +118,8 @@ image: build
 .PHONY: test
 test: packr
 	go test ./...
+
+.PHONY: e2e-test
+e2e-test: $(KUBE_LINTER_BIN)
+	KUBE_LINTER_BIN="$(KUBE_LINTER_BIN)" go test -tags e2e -count=1 ./e2etests/...
 

--- a/e2etests/empty.go
+++ b/e2etests/empty.go
@@ -1,0 +1,3 @@
+package e2etests
+
+// Empty file with no build tag to keep the Go compiler happy.

--- a/e2etests/sanity_test.go
+++ b/e2etests/sanity_test.go
@@ -1,0 +1,44 @@
+// +build e2e
+
+package e2etests
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	kubeLinterBinEnv = "KUBE_LINTER_BIN"
+)
+
+func TestKubeLinterWithBuiltInChecksDoesntCrashOnHelmChartsRepo(t *testing.T) {
+	kubeLinterBin := os.Getenv(kubeLinterBinEnv)
+	require.NotEmpty(t, kubeLinterBin, "Please set %s", kubeLinterBinEnv)
+
+	_, err := os.Stat(kubeLinterBin)
+	require.NoError(t, err)
+
+	tmpDir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.RemoveAll(tmpDir))
+	}()
+
+	chartsDir := filepath.Join(tmpDir, "charts")
+
+	gitCloneOut, err := exec.Command("git", "clone", "git@github.com:helm/charts.git", chartsDir).CombinedOutput()
+	require.NoError(t, err, "Git clone failed. output: %s", string(gitCloneOut))
+
+	kubeLinterOut, err := exec.Command(kubeLinterBin, "lint", chartsDir).CombinedOutput()
+	// Something will fail for sure, so kube-linter will not return a success code.
+	require.Error(t, err)
+	exitErr, ok := err.(*exec.ExitError)
+	require.True(t, ok)
+	assert.Equal(t, 1, exitErr.ExitCode(), "unexpected exit code: %d; output from kube-linter: %v", exitErr.ExitCode(), string(kubeLinterOut))
+}

--- a/e2etests/sanity_test.go
+++ b/e2etests/sanity_test.go
@@ -35,7 +35,7 @@ func TestKubeLinterWithBuiltInChecksDoesntCrashOnHelmChartsRepo(t *testing.T) {
 	gitCloneOut, err := exec.Command("git", "clone", "git@github.com:helm/charts.git", chartsDir).CombinedOutput()
 	require.NoError(t, err, "Git clone failed. output: %s", string(gitCloneOut))
 
-	kubeLinterOut, err := exec.Command(kubeLinterBin, "lint", chartsDir).CombinedOutput()
+	kubeLinterOut, err := exec.Command(kubeLinterBin, "lint", chartsDir, "--config", "testdata/all-built-in-config.yaml").CombinedOutput()
 	// Something will fail for sure, so kube-linter will not return a success code.
 	require.Error(t, err)
 	exitErr, ok := err.(*exec.ExitError)

--- a/e2etests/testdata/all-built-in-config.yaml
+++ b/e2etests/testdata/all-built-in-config.yaml
@@ -1,0 +1,3 @@
+checks:
+  addAllBuiltIn: true
+

--- a/e2etests/testdata/all-built-in-config.yaml
+++ b/e2etests/testdata/all-built-in-config.yaml
@@ -1,3 +1,2 @@
 checks:
   addAllBuiltIn: true
-

--- a/internal/templates/mismatchingselector/template.go
+++ b/internal/templates/mismatchingselector/template.go
@@ -10,8 +10,6 @@ import (
 	"golang.stackrox.io/kube-linter/internal/objectkinds"
 	"golang.stackrox.io/kube-linter/internal/templates"
 	"golang.stackrox.io/kube-linter/internal/templates/mismatchingselector/internal/params"
-	v1 "k8s.io/api/batch/v1"
-	"k8s.io/api/batch/v1beta1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -29,15 +27,11 @@ func init() {
 		Instantiate: params.WrapInstantiateFunc(func(_ params.Params) (check.Func, error) {
 			return func(_ *lintcontext.LintContext, object lintcontext.Object) []diagnostic.Diagnostic {
 				selector, found := extract.Selector(object.K8sObject)
+
 				if !found {
 					return nil
 				}
-				if selector == nil || (len(selector.MatchLabels) == 0 && len(selector.MatchExpressions) == 0) {
-					switch object.K8sObject.(type) {
-					// It's okay for CronJobs and Jobs not to have selectors.
-					case *v1beta1.CronJob, *v1.Job:
-						return nil
-					}
+				if len(selector.MatchLabels) == 0 && len(selector.MatchExpressions) == 0 {
 					return []diagnostic.Diagnostic{{
 						Message: "object has no selector specified",
 					}}

--- a/internal/templates/mismatchingselector/template.go
+++ b/internal/templates/mismatchingselector/template.go
@@ -10,6 +10,8 @@ import (
 	"golang.stackrox.io/kube-linter/internal/objectkinds"
 	"golang.stackrox.io/kube-linter/internal/templates"
 	"golang.stackrox.io/kube-linter/internal/templates/mismatchingselector/internal/params"
+	v1 "k8s.io/api/batch/v1"
+	"k8s.io/api/batch/v1beta1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -27,11 +29,15 @@ func init() {
 		Instantiate: params.WrapInstantiateFunc(func(_ params.Params) (check.Func, error) {
 			return func(_ *lintcontext.LintContext, object lintcontext.Object) []diagnostic.Diagnostic {
 				selector, found := extract.Selector(object.K8sObject)
-
 				if !found {
 					return nil
 				}
-				if len(selector.MatchLabels) == 0 && len(selector.MatchExpressions) == 0 {
+				if selector == nil || (len(selector.MatchLabels) == 0 && len(selector.MatchExpressions) == 0) {
+					switch object.K8sObject.(type) {
+					// It's okay for CronJobs and Jobs not to have selectors.
+					case *v1beta1.CronJob, *v1.Job:
+						return nil
+					}
 					return []diagnostic.Diagnostic{{
 						Message: "object has no selector specified",
 					}}


### PR DESCRIPTION
I found a bug where we would crash on CronJobs and Jobs without selectors defined. Fix this bug, and also add an E2E test that pulls the Helm chart repo from https://github.com/helm/charts and runs KubeLinter on it, and makes sure it doesn't panic.

Example build showing failure before I fixed the issue: https://app.circleci.com/pipelines/github/stackrox/kube-linter/250/workflows/c7cf15e6-4d3b-43ef-badd-92c1575ce77a/jobs/656