### PR TITLE
Fix the matching of the namespace in the danglingservice check

### DIFF
--- a/internal/templates/danglingservice/template.go
+++ b/internal/templates/danglingservice/template.go
@@ -52,7 +52,7 @@ func init() {
 					if !hasPods {
 						continue
 					}
-					if service.Namespace != podTemplateSpec.Namespace {
+					if service.Namespace != obj.K8sObject.GetNamespace() {
 						continue
 					}
 					if labelSelector.Matches(labels.Set(podTemplateSpec.Labels)) {


### PR DESCRIPTION
Namespace needs to be specified for the top-level workload object (deployment etc.) but can be (and usually is) omitted from the pod template specification. Therefore, use the top-level object's namespaces to see if it is in the same namespace as the service.

Fixes #82 