### PR TITLE
Allow users to specify the topology key for the anti-affinity check

### DIFF
--- a/docs/generated/templates.md
+++ b/docs/generated/templates.md
@@ -18,6 +18,14 @@ KubeLinter supports the following templates:
 		"type": "integer",
 		"description": "The minimum number of replicas a deployment must have before anti-affinity is enforced on it",
 		"required": false
+	},
+	{
+		"name": "topologyKey",
+		"type": "string",
+		"description": "The topology key that the anti-affinity term should use. If not specified, it defaults to \"kubernetes.io/hostname\".",
+		"required": false,
+		"regexAllowed": true,
+		"negationAllowed": true
 	}
 ]
 

--- a/internal/lintcontext/mocks/container.go
+++ b/internal/lintcontext/mocks/container.go
@@ -1,29 +1,16 @@
 package mocks
 
 import (
-	"github.com/pkg/errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 )
 
 // AddContainerToPod adds a mock container to the specified pod under context
-func (l *MockLintContext) AddContainerToPod(
-	podName, containerName, image string,
-	ports []v1.ContainerPort,
-	env []v1.EnvVar,
-	sc *v1.SecurityContext,
-) error {
+func (l *MockLintContext) AddContainerToPod(t *testing.T, podName string, container v1.Container) {
 	pod, ok := l.pods[podName]
-	if !ok {
-		return errors.Errorf("pod with name %q is not found", podName)
-	}
+	require.True(t, ok, "pod with name %s not found", podName)
 	// TODO: keep supporting other fields
-	pod.Spec.Containers = append(pod.Spec.Containers, v1.Container{
-		Name:            containerName,
-		Image:           image,
-		Ports:           ports,
-		Env:             env,
-		Resources:       v1.ResourceRequirements{},
-		SecurityContext: sc,
-	})
-	return nil
+	pod.Spec.Containers = append(pod.Spec.Containers, container)
 }

--- a/internal/lintcontext/mocks/container.go
+++ b/internal/lintcontext/mocks/container.go
@@ -4,13 +4,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	appsV1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 )
 
-// AddContainerToPod adds a mock container to the specified pod under context
-func (l *MockLintContext) AddContainerToPod(t *testing.T, podName string, container v1.Container) {
-	pod, ok := l.pods[podName]
-	require.True(t, ok, "pod with name %s not found", podName)
+// AddContainerToDeployment adds a mock container to the specified pod under context
+func (l *MockLintContext) AddContainerToDeployment(t *testing.T, deploymentName string, container v1.Container) {
+	deployment, ok := l.objects[deploymentName].(*appsV1.Deployment)
+	require.True(t, ok, "deployment with name %s not found", deploymentName)
 	// TODO: keep supporting other fields
-	pod.Spec.Containers = append(pod.Spec.Containers, container)
+	deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, container)
 }

--- a/internal/lintcontext/mocks/context.go
+++ b/internal/lintcontext/mocks/context.go
@@ -1,19 +1,19 @@
 package mocks
 
 import (
+	"golang.stackrox.io/kube-linter/internal/k8sutil"
 	"golang.stackrox.io/kube-linter/internal/lintcontext"
-	v1 "k8s.io/api/core/v1"
 )
 
 // MockLintContext is mock implementation of the LintContext used in unit tests
 type MockLintContext struct {
-	pods map[string]*v1.Pod
+	objects map[string]k8sutil.Object
 }
 
 // Objects returns all the objects under this MockLintContext
 func (l *MockLintContext) Objects() []lintcontext.Object {
-	result := make([]lintcontext.Object, 0, len(l.pods))
-	for _, p := range l.pods {
+	result := make([]lintcontext.Object, 0, len(l.objects))
+	for _, p := range l.objects {
 		result = append(result, lintcontext.Object{Metadata: lintcontext.ObjectMetadata{}, K8sObject: p})
 	}
 	return result
@@ -26,5 +26,5 @@ func (l *MockLintContext) InvalidObjects() []lintcontext.InvalidObject {
 
 // NewMockContext returns an empty mockLintContext
 func NewMockContext() *MockLintContext {
-	return &MockLintContext{pods: make(map[string]*v1.Pod)}
+	return &MockLintContext{objects: make(map[string]k8sutil.Object)}
 }

--- a/internal/lintcontext/mocks/pod.go
+++ b/internal/lintcontext/mocks/pod.go
@@ -4,31 +4,30 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	appsV1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// AddMockPod adds a mock Pod to LintContext
-func (l *MockLintContext) AddMockPod(
-	podName, namespace string,
-	labels, annotations map[string]string,
-) {
-	l.pods[podName] =
-		&v1.Pod{
-			ObjectMeta: metaV1.ObjectMeta{
-				Name:        podName,
-				Namespace:   namespace,
-				Labels:      labels,
-				Annotations: annotations,
-			},
-		}
+// AddMockDeployment adds a mock Deployment to LintContext
+func (l *MockLintContext) AddMockDeployment(t *testing.T, name string) {
+	require.NotEmpty(t, name)
+	l.objects[name] = &appsV1.Deployment{
+		ObjectMeta: metaV1.ObjectMeta{Name: name},
+	}
 }
 
-// AddSecurityContextToPod adds a security context to the pod specified by name
-func (l *MockLintContext) AddSecurityContextToPod(t *testing.T, podName string,
+func (l *MockLintContext) ModifyDeployment(t *testing.T, name string, f func(deployment *appsV1.Deployment)) {
+	dep, ok := l.objects[name].(*appsV1.Deployment)
+	require.True(t, ok)
+	f(dep)
+}
+
+
+// AddSecurityContextToDeployment adds a security context to the deployment specified by name
+func (l *MockLintContext) AddSecurityContextToDeployment(t *testing.T, deploymentName string,
 	securityContext *v1.PodSecurityContext) {
-	pod, ok := l.pods[podName]
-	require.True(t, ok, "pod with name %s not added", podName)
-	// TODO: keep supporting other fields
-	pod.Spec.SecurityContext = securityContext
+	deployment, ok := l.objects[deploymentName].(*appsV1.Deployment)
+	require.True(t, ok, "deployment with name %s not added", deploymentName)
+	deployment.Spec.Template.Spec.SecurityContext = securityContext
 }

--- a/internal/lintcontext/mocks/pod.go
+++ b/internal/lintcontext/mocks/pod.go
@@ -17,12 +17,12 @@ func (l *MockLintContext) AddMockDeployment(t *testing.T, name string) {
 	}
 }
 
+// ModifyDeployment modifies a given deployment in the context via the passed function.
 func (l *MockLintContext) ModifyDeployment(t *testing.T, name string, f func(deployment *appsV1.Deployment)) {
 	dep, ok := l.objects[name].(*appsV1.Deployment)
 	require.True(t, ok)
 	f(dep)
 }
-
 
 // AddSecurityContextToDeployment adds a security context to the deployment specified by name
 func (l *MockLintContext) AddSecurityContextToDeployment(t *testing.T, deploymentName string,

--- a/internal/lintcontext/mocks/pod.go
+++ b/internal/lintcontext/mocks/pod.go
@@ -1,53 +1,34 @@
 package mocks
 
 import (
-	"github.com/pkg/errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // AddMockPod adds a mock Pod to LintContext
 func (l *MockLintContext) AddMockPod(
-	podName, namespace, clusterName string,
+	podName, namespace string,
 	labels, annotations map[string]string,
 ) {
 	l.pods[podName] =
 		&v1.Pod{
-			TypeMeta: metaV1.TypeMeta{},
 			ObjectMeta: metaV1.ObjectMeta{
 				Name:        podName,
 				Namespace:   namespace,
 				Labels:      labels,
 				Annotations: annotations,
-				ClusterName: clusterName,
 			},
-			Spec:   v1.PodSpec{},
-			Status: v1.PodStatus{},
 		}
 }
 
 // AddSecurityContextToPod adds a security context to the pod specified by name
-func (l *MockLintContext) AddSecurityContextToPod(
-	podName string,
-	runAsUser *int64,
-	runAsNonRoot *bool,
-) error {
+func (l *MockLintContext) AddSecurityContextToPod(t *testing.T, podName string,
+	securityContext *v1.PodSecurityContext) {
 	pod, ok := l.pods[podName]
-	if !ok {
-		return errors.Errorf("pod with name %q is not found", podName)
-	}
+	require.True(t, ok, "pod with name %s not added", podName)
 	// TODO: keep supporting other fields
-	pod.Spec.SecurityContext = &v1.PodSecurityContext{
-		SELinuxOptions:      nil,
-		WindowsOptions:      nil,
-		RunAsUser:           runAsUser,
-		RunAsGroup:          nil,
-		RunAsNonRoot:        runAsNonRoot,
-		SupplementalGroups:  nil,
-		FSGroup:             nil,
-		Sysctls:             nil,
-		FSGroupChangePolicy: nil,
-		SeccompProfile:      nil,
-	}
-	return nil
+	pod.Spec.SecurityContext = securityContext
 }

--- a/internal/pointers/pointers.go
+++ b/internal/pointers/pointers.go
@@ -5,6 +5,11 @@ func Bool(b bool) *bool {
 	return &b
 }
 
+// Int32 returns a pointer to an int32.
+func Int32(i int32) *int32 {
+	return &i
+}
+
 // Int64 returns a pointer to an int64.
 func Int64(i int64) *int64 {
 	return &i

--- a/internal/stringutils/ternary.go
+++ b/internal/stringutils/ternary.go
@@ -1,0 +1,9 @@
+package stringutils
+
+// Ternary does a ternary based on the condition.
+func Ternary(condition bool, ifTrue, ifFalse string) string {
+	if condition {
+		return ifTrue
+	}
+	return ifFalse
+}

--- a/internal/templates/antiaffinity/internal/params/gen-params.go
+++ b/internal/templates/antiaffinity/internal/params/gen-params.go
@@ -33,8 +33,25 @@ var (
 }
 `)
 
+	topologyKeyParamDesc = util.MustParseParameterDesc(`{
+	"Name": "topologyKey",
+	"Type": "string",
+	"Description": "The topology key that the anti-affinity term should use. If not specified, it defaults to \"kubernetes.io/hostname\".",
+	"Examples": null,
+	"Enum": null,
+	"SubParameters": null,
+	"ArrayElemType": "",
+	"Required": false,
+	"NoRegex": false,
+	"NotNegatable": false,
+	"XXXStructFieldName": "TopologyKey",
+	"XXXIsPointer": false
+}
+`)
+
 	ParamDescs = []check.ParameterDesc{
 		minReplicasParamDesc,
+		topologyKeyParamDesc,
 	}
 )
 

--- a/internal/templates/antiaffinity/internal/params/params.go
+++ b/internal/templates/antiaffinity/internal/params/params.go
@@ -5,4 +5,8 @@ type Params struct {
 
 	// The minimum number of replicas a deployment must have before anti-affinity is enforced on it
 	MinReplicas int
+
+	// The topology key that the anti-affinity term should use.
+	// If not specified, it defaults to "kubernetes.io/hostname".
+	TopologyKey string
 }

--- a/internal/templates/antiaffinity/template.go
+++ b/internal/templates/antiaffinity/template.go
@@ -9,6 +9,7 @@ import (
 	"golang.stackrox.io/kube-linter/internal/lintcontext"
 	"golang.stackrox.io/kube-linter/internal/matcher"
 	"golang.stackrox.io/kube-linter/internal/objectkinds"
+	"golang.stackrox.io/kube-linter/internal/stringutils"
 	"golang.stackrox.io/kube-linter/internal/templates"
 	"golang.stackrox.io/kube-linter/internal/templates/antiaffinity/internal/params"
 	coreV1 "k8s.io/api/core/v1"
@@ -20,11 +21,9 @@ const (
 	templateKey = "anti-affinity"
 )
 
-
 func defaultTopologyKeyMatcher(topologyKey string) bool {
 	return topologyKey == "kubernetes.io/hostname"
 }
-
 
 func init() {
 	templates.Register(check.Template{
@@ -73,7 +72,9 @@ func init() {
 						}
 					}
 				}
-				return []diagnostic.Diagnostic{{Message: fmt.Sprintf("object has %d replicas but does not specify inter pod anti-affinity", replicas)}}
+				return []diagnostic.Diagnostic{
+					{Message: fmt.Sprintf("object has %d %s but does not specify inter pod anti-affinity", replicas, stringutils.Ternary(replicas > 1, "replicas", "replica"))},
+				}
 			}, nil
 		}),
 	})

--- a/internal/templates/antiaffinity/template.go
+++ b/internal/templates/antiaffinity/template.go
@@ -16,14 +16,20 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
+const (
+	templateKey = "anti-affinity"
+)
+
+
 func defaultTopologyKeyMatcher(topologyKey string) bool {
 	return topologyKey == "kubernetes.io/hostname"
 }
 
+
 func init() {
 	templates.Register(check.Template{
 		HumanName:   "Anti affinity not specified",
-		Key:         "anti-affinity",
+		Key:         templateKey,
 		Description: "Flag objects with multiple replicas but inter-pod anti affinity not specified in the pod template spec",
 		SupportedObjectKinds: check.ObjectKindsDesc{
 			ObjectKinds: []string{objectkinds.DeploymentLike},

--- a/internal/templates/antiaffinity/template_test.go
+++ b/internal/templates/antiaffinity/template_test.go
@@ -1,0 +1,55 @@
+package antiaffinity
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"golang.stackrox.io/kube-linter/internal/diagnostic"
+	"golang.stackrox.io/kube-linter/internal/lintcontext/mocks"
+	"golang.stackrox.io/kube-linter/internal/templates"
+	"golang.stackrox.io/kube-linter/internal/templates/containercapabilities/internal/params"
+	v1 "k8s.io/api/core/v1"
+)
+
+var (
+	podName       = "test-pod"
+	containerName = "test-container"
+)
+
+func TestAntiAffinity(t *testing.T) {
+	suite.Run(t, new(AntiAffinityTestSuite))
+}
+
+type AntiAffinityTestSuite struct {
+	templates.TemplateTestSuite
+
+	ctx *mocks.MockLintContext
+}
+
+func (s *AntiAffinityTestSuite) SetupTest() {
+	s.Init(templateKey)
+	s.ctx = mocks.NewMockContext()
+}
+
+func (s *AntiAffinityTestSuite) TestAntiAffinity() {
+	addCaps := []v1.Capability{"FORBIDDEN_CAP", "ALLOWED_CAP"}
+	dropCaps := []v1.Capability{"DROPPED_CAP"}
+
+	s.ctx.AddMockPod(podName)
+	s.addPodAndAddContainerWithCaps(addCaps, dropCaps)
+
+	s.Validate(s.ctx, []templates.TestCase{
+		{
+			Param: params.Params{
+				ForbiddenCapabilities: []string{"FORBIDDEN_CAP", "DROPPED_CAP"},
+				Exceptions:            nil,
+			},
+			Diagnostics: []diagnostic.Diagnostic{
+				{Message: fmt.Sprintf(addListDiagMsgFmt, containerName, "FORBIDDEN_CAP")},
+				{Message: fmt.Sprintf(dropListDiagMsgFmt, containerName, dropCaps, "FORBIDDEN_CAP")},
+			},
+			ExpectInstantiationError: false,
+		},
+	})
+}

--- a/internal/templates/antiaffinity/template_test.go
+++ b/internal/templates/antiaffinity/template_test.go
@@ -1,20 +1,17 @@
 package antiaffinity
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 	"golang.stackrox.io/kube-linter/internal/diagnostic"
 	"golang.stackrox.io/kube-linter/internal/lintcontext/mocks"
+	"golang.stackrox.io/kube-linter/internal/pointers"
 	"golang.stackrox.io/kube-linter/internal/templates"
-	"golang.stackrox.io/kube-linter/internal/templates/containercapabilities/internal/params"
+	"golang.stackrox.io/kube-linter/internal/templates/antiaffinity/internal/params"
+	appsV1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-)
-
-var (
-	podName       = "test-pod"
-	containerName = "test-container"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestAntiAffinity(t *testing.T) {
@@ -32,23 +29,125 @@ func (s *AntiAffinityTestSuite) SetupTest() {
 	s.ctx = mocks.NewMockContext()
 }
 
-func (s *AntiAffinityTestSuite) TestAntiAffinity() {
-	addCaps := []v1.Capability{"FORBIDDEN_CAP", "ALLOWED_CAP"}
-	dropCaps := []v1.Capability{"DROPPED_CAP"}
+func (s *AntiAffinityTestSuite) addDeploymentWithReplicas(name string, replicas int32) {
+	s.ctx.AddMockDeployment(s.T(), name)
+	s.ctx.ModifyDeployment(s.T(), name, func(deployment *appsV1.Deployment) {
+		deployment.Spec.Replicas = pointers.Int32(replicas)
+	})
+}
 
-	s.ctx.AddMockPod(podName)
-	s.addPodAndAddContainerWithCaps(addCaps, dropCaps)
+func (s *AntiAffinityTestSuite) TestNoAntiAffinity() {
+	const (
+		noExplicitReplicasDepName = "no-explicit-replicas"
+		oneReplicaDepName         = "one-replica"
+		twoReplicasDepName        = "two-replicas"
+	)
+	s.ctx.AddMockDeployment(s.T(), noExplicitReplicasDepName)
+	s.addDeploymentWithReplicas(oneReplicaDepName, 1)
+	s.addDeploymentWithReplicas(twoReplicasDepName, 2)
 
 	s.Validate(s.ctx, []templates.TestCase{
 		{
 			Param: params.Params{
-				ForbiddenCapabilities: []string{"FORBIDDEN_CAP", "DROPPED_CAP"},
-				Exceptions:            nil,
+				MinReplicas: 2,
 			},
-			Diagnostics: []diagnostic.Diagnostic{
-				{Message: fmt.Sprintf(addListDiagMsgFmt, containerName, "FORBIDDEN_CAP")},
-				{Message: fmt.Sprintf(dropListDiagMsgFmt, containerName, dropCaps, "FORBIDDEN_CAP")},
+			Diagnostics: map[string][]diagnostic.Diagnostic{
+				twoReplicasDepName: {
+					{Message: "object has 2 replicas but does not specify inter pod anti-affinity"},
+				},
 			},
+			ExpectInstantiationError: false,
+		},
+	})
+	s.Validate(s.ctx, []templates.TestCase{
+		{
+			Param: params.Params{
+				MinReplicas: 1,
+			},
+			Diagnostics: map[string][]diagnostic.Diagnostic{
+				// Replicas defaults to 1.
+				noExplicitReplicasDepName: {
+					{Message: "object has 1 replica but does not specify inter pod anti-affinity"},
+				},
+				oneReplicaDepName: {
+					{Message: "object has 1 replica but does not specify inter pod anti-affinity"},
+				},
+				twoReplicasDepName: {
+					{Message: "object has 2 replicas but does not specify inter pod anti-affinity"},
+				},
+			},
+			ExpectInstantiationError: false,
+		},
+	})
+}
+
+func (s *AntiAffinityTestSuite) addDeploymentWithAntiAffinity(name string, replicas int32, topologyKey string) {
+	s.addDeploymentWithReplicas(name, replicas)
+	s.ctx.ModifyDeployment(s.T(), name, func(deployment *appsV1.Deployment) {
+		deployment.Spec.Template.Labels = map[string]string{"app": name}
+		deployment.Spec.Template.Spec.Affinity = &v1.Affinity{
+			PodAntiAffinity: &v1.PodAntiAffinity{
+				PreferredDuringSchedulingIgnoredDuringExecution: []v1.WeightedPodAffinityTerm{
+					{
+						Weight: 1,
+						PodAffinityTerm: v1.PodAffinityTerm{
+							TopologyKey:   topologyKey,
+							LabelSelector: &metaV1.LabelSelector{MatchLabels: map[string]string{"app": name}},
+						},
+					},
+				},
+			},
+		}
+	})
+
+}
+
+func (s *AntiAffinityTestSuite) TestWithAntiAffinity() {
+	const (
+		kubernetesIOHostnameDepName = "kubernetes-io-hostname"
+		otherValidKeyDepName        = "other-valid-key"
+		weirdKeyDepName             = "weird-key"
+	)
+	s.addDeploymentWithAntiAffinity(kubernetesIOHostnameDepName, 2, "kubernetes.io/hostname")
+	s.addDeploymentWithAntiAffinity(otherValidKeyDepName, 3, "other.valid/key")
+	s.addDeploymentWithAntiAffinity(weirdKeyDepName, 4, "weird/key")
+
+	s.Validate(s.ctx, []templates.TestCase{
+		{
+			Param: params.Params{
+				MinReplicas: 2,
+			},
+			Diagnostics: map[string][]diagnostic.Diagnostic{
+				otherValidKeyDepName: {
+					{Message: "object has 3 replicas but does not specify inter pod anti-affinity"},
+				},
+				weirdKeyDepName: {
+					{Message: "object has 4 replicas but does not specify inter pod anti-affinity"},
+				},
+			},
+			ExpectInstantiationError: false,
+		},
+		{
+			Param: params.Params{
+				MinReplicas: 2,
+				TopologyKey: "other.valid/key",
+			},
+			Diagnostics: map[string][]diagnostic.Diagnostic{
+				kubernetesIOHostnameDepName: {
+					{Message: "object has 2 replicas but does not specify inter pod anti-affinity"},
+				},
+				weirdKeyDepName: {
+					{Message: "object has 4 replicas but does not specify inter pod anti-affinity"},
+				},
+			},
+			ExpectInstantiationError: false,
+		},
+		{
+			Param: params.Params{
+				MinReplicas: 2,
+				TopologyKey: ".+",
+			},
+			Diagnostics:              nil,
 			ExpectInstantiationError: false,
 		},
 	})

--- a/internal/templates/containercapabilities/template_test.go
+++ b/internal/templates/containercapabilities/template_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 var (
-	podName       = "test-pod"
-	containerName = "test-container"
+	deploymentName = "test-deployment"
+	containerName  = "test-container"
 )
 
 func TestContainerCapabilities(t *testing.T) {
@@ -44,9 +44,11 @@ func (s *ContainerCapabilitiesTestSuite) TestForbiddenCapabilities() {
 				ForbiddenCapabilities: []string{"FORBIDDEN_CAP", "DROPPED_CAP"},
 				Exceptions:            nil,
 			},
-			Diagnostics: []diagnostic.Diagnostic{
-				{Message: fmt.Sprintf(addListDiagMsgFmt, containerName, "FORBIDDEN_CAP")},
-				{Message: fmt.Sprintf(dropListDiagMsgFmt, containerName, dropCaps, "FORBIDDEN_CAP")},
+			Diagnostics: map[string][]diagnostic.Diagnostic{
+				deploymentName: {
+					{Message: fmt.Sprintf(addListDiagMsgFmt, containerName, "FORBIDDEN_CAP")},
+					{Message: fmt.Sprintf(dropListDiagMsgFmt, containerName, dropCaps, "FORBIDDEN_CAP")},
+				},
 			},
 			ExpectInstantiationError: false,
 		},
@@ -66,11 +68,13 @@ func (s *ContainerCapabilitiesTestSuite) TestForbiddenCapabilitiesWithAll() {
 				ForbiddenCapabilities: []string{"all"},
 				Exceptions:            nil,
 			},
-			Diagnostics: []diagnostic.Diagnostic{
-				{Message: fmt.Sprintf(addListWithAllDiagMsgFmt, containerName, "CAP_1")},
-				{Message: fmt.Sprintf(addListWithAllDiagMsgFmt, containerName, "CAP_2")},
-				{Message: fmt.Sprintf(addListWithAllDiagMsgFmt, containerName, "CAP_3")},
-				{Message: fmt.Sprintf(dropListWithAllDiagMsgFmt, containerName, dropCaps)},
+			Diagnostics: map[string][]diagnostic.Diagnostic{
+				deploymentName: {
+					{Message: fmt.Sprintf(addListWithAllDiagMsgFmt, containerName, "CAP_1")},
+					{Message: fmt.Sprintf(addListWithAllDiagMsgFmt, containerName, "CAP_2")},
+					{Message: fmt.Sprintf(addListWithAllDiagMsgFmt, containerName, "CAP_3")},
+					{Message: fmt.Sprintf(dropListWithAllDiagMsgFmt, containerName, dropCaps)},
+				},
 			},
 			ExpectInstantiationError: false,
 		},
@@ -81,9 +85,11 @@ func (s *ContainerCapabilitiesTestSuite) TestForbiddenCapabilitiesWithAll() {
 				ForbiddenCapabilities: []string{"AlL"},
 				Exceptions:            []string{"CAP_1", "CAP_2"},
 			},
-			Diagnostics: []diagnostic.Diagnostic{
-				{Message: fmt.Sprintf(addListWithAllDiagMsgFmt, containerName, "CAP_3")},
-				{Message: fmt.Sprintf(dropListWithAllDiagMsgFmt, containerName, dropCaps)},
+			Diagnostics: map[string][]diagnostic.Diagnostic{
+				deploymentName: {
+					{Message: fmt.Sprintf(addListWithAllDiagMsgFmt, containerName, "CAP_3")},
+					{Message: fmt.Sprintf(dropListWithAllDiagMsgFmt, containerName, dropCaps)},
+				},
 			},
 			ExpectInstantiationError: false,
 		},
@@ -102,9 +108,11 @@ func (s *ContainerCapabilitiesTestSuite) TestAddListHasAll() {
 				ForbiddenCapabilities: []string{"CAP_1"},
 				Exceptions:            nil,
 			},
-			Diagnostics: []diagnostic.Diagnostic{
-				{Message: fmt.Sprintf(addListDiagMsgFmt, containerName, "all")},
-				{Message: fmt.Sprintf(dropListDiagMsgFmt, containerName, dropCaps, "CAP_1")},
+			Diagnostics: map[string][]diagnostic.Diagnostic{
+				deploymentName: {
+					{Message: fmt.Sprintf(addListDiagMsgFmt, containerName, "all")},
+					{Message: fmt.Sprintf(dropListDiagMsgFmt, containerName, dropCaps, "CAP_1")},
+				},
 			},
 			ExpectInstantiationError: false,
 		},
@@ -124,7 +132,7 @@ func (s *ContainerCapabilitiesTestSuite) TestDropListHasAll() {
 				ForbiddenCapabilities: []string{"CAP_1", "CAP_2"},
 				Exceptions:            nil,
 			},
-			Diagnostics:              []diagnostic.Diagnostic{},
+			Diagnostics:              nil,
 			ExpectInstantiationError: false,
 		},
 		// Case 2: forbidden caps include "all"
@@ -133,8 +141,10 @@ func (s *ContainerCapabilitiesTestSuite) TestDropListHasAll() {
 				ForbiddenCapabilities: []string{"all"},
 				Exceptions:            nil,
 			},
-			Diagnostics: []diagnostic.Diagnostic{
-				{Message: fmt.Sprintf(addListWithAllDiagMsgFmt, containerName, "FORGIVEN_CAP")},
+			Diagnostics: map[string][]diagnostic.Diagnostic{
+				deploymentName: {
+					{Message: fmt.Sprintf(addListWithAllDiagMsgFmt, containerName, "FORGIVEN_CAP")},
+				},
 			},
 			ExpectInstantiationError: false,
 		},
@@ -144,7 +154,7 @@ func (s *ContainerCapabilitiesTestSuite) TestDropListHasAll() {
 				ForbiddenCapabilities: []string{"all"},
 				Exceptions:            []string{"FORGIVEN_CAP"},
 			},
-			Diagnostics:              []diagnostic.Diagnostic{},
+			Diagnostics:              nil,
 			ExpectInstantiationError: false,
 		},
 	})
@@ -162,15 +172,15 @@ func (s *ContainerCapabilitiesTestSuite) TestInvalidParams() {
 				ForbiddenCapabilities: []string{"THIS_IS_NOT_All_CAP"},
 				Exceptions:            []string{"BUT_WE_SPECIFY_EXCEPTIONS"},
 			},
-			Diagnostics:              []diagnostic.Diagnostic{},
+			Diagnostics:              nil,
 			ExpectInstantiationError: true,
 		},
 	})
 }
 
 func (s *ContainerCapabilitiesTestSuite) addPodAndAddContainerWithCaps(addCaps, dropCaps []v1.Capability) {
-	s.ctx.AddMockPod(podName,  "", nil, nil)
-	s.ctx.AddContainerToPod(s.T(), podName, v1.Container{Name: containerName, SecurityContext: &v1.SecurityContext{
+	s.ctx.AddMockDeployment(s.T(), deploymentName)
+	s.ctx.AddContainerToDeployment(s.T(), deploymentName, v1.Container{Name: containerName, SecurityContext: &v1.SecurityContext{
 		Capabilities: &v1.Capabilities{
 			Add:  addCaps,
 			Drop: dropCaps,

--- a/internal/templates/containercapabilities/template_test.go
+++ b/internal/templates/containercapabilities/template_test.go
@@ -169,11 +169,11 @@ func (s *ContainerCapabilitiesTestSuite) TestInvalidParams() {
 }
 
 func (s *ContainerCapabilitiesTestSuite) addPodAndAddContainerWithCaps(addCaps, dropCaps []v1.Capability) {
-	s.ctx.AddMockPod(podName, "", "", nil, nil)
-	s.ctx.AddContainerToPod(podName, containerName, "", nil, nil, &v1.SecurityContext{
+	s.ctx.AddMockPod(podName,  "", nil, nil)
+	s.ctx.AddContainerToPod(s.T(), podName, v1.Container{Name: containerName, SecurityContext: &v1.SecurityContext{
 		Capabilities: &v1.Capabilities{
 			Add:  addCaps,
 			Drop: dropCaps,
 		},
-	})
+	}})
 }


### PR DESCRIPTION
This allows users to allow inter-pod anti-affinity to use an arbitrary label (example: `topologyKey: failure-domain.beta.kubernetes.io/zone`), not just `kubernetes.io/hostname`.