### PR TITLE
Dockerfile: switch from scratch to Alpine

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM scratch
+FROM alpine:latest
 
 COPY ./bin/kube-linter /
 


### PR DESCRIPTION
This adds a shell and other basic system utilities to the image, which
makes kube-linter usable with more CI systems such as GitLab CI that
require a shell. Fixes: #114.