### PR TITLE
Add Alpine base image variant

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,11 +108,15 @@ jobs:
           fi
           docker login -u "$DOCKER_IO_PUSH_USERNAME" -p "$DOCKER_IO_PUSH_PASSWORD"
           img="stackrox/kube-linter:$(./get-tag)"
+          alpine_img="${img}-alpine"
           docker push "${img}"
+          docker push "${alpine_img}"
 
           if [[ -n "${CIRCLE_TAG}" ]]; then
             docker tag "${img}" stackrox/kube-linter:latest
             docker push stackrox/kube-linter:latest
+            docker tag "${alpine_img}" stackrox/kube-linter:latest-alpine
+            docker push stackrox/kube-linter:latest-alpine
           fi
 
 commands:

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,8 @@ $(KUBE_LINTER_BIN):
 .PHONY: image
 image: build
 	@cp bin/linux/kube-linter image/bin
-	@docker build -t "stackrox/kube-linter:$(TAG)" image/
+	@docker build -t "stackrox/kube-linter:$(TAG)" -f image/Dockerfile image/
+	@docker build -t "stackrox/kube-linter:$(TAG)-alpine" -f image/Dockerfile_alpine image/
 ##########
 ## Test ##
 ##########

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM scratch
+FROM alpine:latest
 
 COPY ./bin/kube-linter /
 

--- a/image/Dockerfile_alpine
+++ b/image/Dockerfile_alpine
@@ -1,4 +1,4 @@
-FROM scratch
+FROM alpine:latest
 
 COPY ./bin/kube-linter /
 


### PR DESCRIPTION
Branched off #115 since I was not able to push commits there directly.

Essentially, create an alpine variant of the Dockerfile and suffix the tag with `-alpine` for those images, similar to what [nginx](https://hub.docker.com/_/nginx) does. Always build and push both images together.