### PR TITLE
Add GitHub stars in Docs

### DIFF
--- a/docs/_navbar.md
+++ b/docs/_navbar.md
@@ -1,0 +1,1 @@
+[![GitHub Repo stars](https://img.shields.io/github/stars/stackrox/kube-linter?label=Give%20us%20a%20star%20on%20GitHub&style=social)](https://github.com/stackrox/kube-linter)

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,6 +18,7 @@
       coverpage: false,
       onlyCover: true,
       loadSidebar: true,
+      loadNavbar: true,
       subMaxLevel: 2,
       auto2top: true,
       copyCode: {

--- a/docs/style.css
+++ b/docs/style.css
@@ -54,6 +54,11 @@
   }
 }
 
+/* GitHub Stars */
+.app-nav img {
+  height: 25px;
+}
+
 /* Icons for Kubernetes and Helm tabs */
 [data-tab="kubernetes"]:before {
   content: url('https://api.iconify.design/cib:kubernetes.svg?height=16');


### PR DESCRIPTION
Added a link to GitHub repository:
- which shows the number of stars
- text says 'Give us a star on GitHub'.
![image](https://user-images.githubusercontent.com/23069445/106543300-27d5a000-6551-11eb-97fc-1a7b8d80bebb.png)

suggestions welcome 👍🏼 