### PR TITLE
Spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Installing KubeLinter from source is as simple as following these steps:
    git clone git@github.com:stackrox/kube-linter.git
    ```
    
-1. Then, complile the source code. This will create the kube-linter binary files for each platform and places them in the `.gobin` folder.
+1. Then, compile the source code. This will create the kube-linter binary files for each platform and places them in the `.gobin` folder.
    
    ```bash
    make build

--- a/docs/configuring-kubelinter.md
+++ b/docs/configuring-kubelinter.md
@@ -55,7 +55,7 @@ checks:
 
 ## Run specific checks
 
-You can use the `include` and `exclue` keys to run only specific checks. For
+You can use the `include` and `exclude` keys to run only specific checks. For
 example,
 - To disable majority of checks and only run few specific checks,
   use `doNotAutoAddDefaults` along with `include`.

--- a/internal/stringutils/default.go
+++ b/internal/stringutils/default.go
@@ -1,18 +1,18 @@
 package stringutils
 
 // OrDefault returns the string if it's not empty, or the default.
-func OrDefault(s, defaul string) string {
+func OrDefault(s, defaultValue string) string {
 	if s != "" {
 		return s
 	}
-	return defaul
+	return defaultValue
 }
 
 // PointerOrDefault returns the string if it's not nil nor empty, or the default.
-func PointerOrDefault(s *string, defaul string) string {
+func PointerOrDefault(s *string, defaultValue string) string {
 	if s == nil {
-		return defaul
+		return defaultValue
 	}
 
-	return OrDefault(*s, defaul)
+	return OrDefault(*s, defaultValue)
 }

--- a/pkg/command/common/markdown.go
+++ b/pkg/command/common/markdown.go
@@ -8,7 +8,7 @@ import (
 	"golang.stackrox.io/kube-linter/internal/utils"
 )
 
-// MustInstantiateTemplate instanties the given go template with a common list of
+// MustInstantiateTemplate instantiates the given go template with a common list of
 // functions. It panics if there is an error.
 func MustInstantiateTemplate(templateStr string, customFuncMap template.FuncMap) *template.Template {
 	tpl, err := template.New("").Funcs(sprig.TxtFuncMap()).Funcs(


### PR DESCRIPTION
This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/kube-linter/commit/7b6895baf10630ea32491458d57ad066327b86b6#commitcomment-49534933

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/kube-linter/commit/4d4a9247e7f37b4237f45abdedb25a05ada8f024

internal/stringutils claims to be internal, so I propose replacing `Default` with `Fallback` which is used in golang projects.

GitHub's diff viewer isn't particularly friendly to this change, but, here are two other diffs which can help:

<details><summary>word-diff</summary>

`git show HEAD~ -M1 --word-diff --oneline`:
```diff
a788700 spelling: fallback
diff --git a/internal/stringutils/default.go b/internal/stringutils/fallback.go
similarity index 18%
rename from internal/stringutils/default.go
rename to internal/stringutils/fallback.go
index 1cc03b8..60617d2 100644
--- a/internal/stringutils/default.go
+++ b/internal/stringutils/fallback.go
@@ -1,18 +1,18 @@
package stringutils

// [-OrDefault-]{+OrFallback+} returns the string if it's not empty, or the [-default.-]{+fallback.+}
func [-OrDefault(s, defaul-]{+OrFallback(s, fallback+} string) string {
	if s != "" {
		return s
	}
	return [-defaul-]{+fallback+}
}

// [-PointerOrDefault-]{+PointerOrFallback+} returns the string if it's not nil nor empty, or the [-default.-]{+fallback.+}
func [-PointerOrDefault(s-]{+PointerOrFallback(s+} *string, [-defaul-]{+fallback+} string) string {
	if s == nil {
		return [-defaul-]{+fallback+}
	}

	return [-OrDefault(*s, defaul)-]{+OrFallback(*s, fallback)+}
}
diff --git a/internal/version/version.go b/internal/version/version.go
index a6aa2aa..b18a790 100644
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -10,5 +10,5 @@ var (

// Get returns the version.
func Get() string {
	return [-stringutils.OrDefault(version,-]{+stringutils.OrFallback(version,+} "development")
}
diff --git a/pkg/diagnostic/diagnostic.go b/pkg/diagnostic/diagnostic.go
index db8d5f5..dd34028 100644
--- a/pkg/diagnostic/diagnostic.go
+++ b/pkg/diagnostic/diagnostic.go
@@ -33,7 +33,7 @@ var (
)

func formatObj(obj k8sutil.Object) string {
	return fmt.Sprintf("%s/%s %s", [-stringutils.OrDefault(obj.GetNamespace(),-]{+stringutils.OrFallback(obj.GetNamespace(),+} "<no namespace>"), obj.GetName(), obj.GetObjectKind().GroupVersionKind())
}

// FormatToTerminal writes the result to the given writer, which is expected to support
diff --git a/pkg/templates/nonexistentserviceaccount/template.go b/pkg/templates/nonexistentserviceaccount/template.go
index 668c454..f61929b 100644
--- a/pkg/templates/nonexistentserviceaccount/template.go
+++ b/pkg/templates/nonexistentserviceaccount/template.go
@@ -36,7 +36,7 @@ func init() {
				if !found {
					return nil
				}
				sa := [-stringutils.OrDefault(podSpec.ServiceAccountName,-]{+stringutils.OrFallback(podSpec.ServiceAccountName,+} podSpec.DeprecatedServiceAccount)
				// Default service account always exists.
				if sa == "" || sa == "default" {
					return nil
diff --git a/pkg/templates/serviceaccount/template.go b/pkg/templates/serviceaccount/template.go
index 5229074..e2531cc 100644
--- a/pkg/templates/serviceaccount/template.go
+++ b/pkg/templates/serviceaccount/template.go
@@ -35,7 +35,7 @@ func init() {
				if !found {
					return nil
				}
				sa := [-stringutils.OrDefault(podSpec.ServiceAccountName,-]{+stringutils.OrFallback(podSpec.ServiceAccountName,+} podSpec.DeprecatedServiceAccount)
				if saMatcher(sa) {
					return []diagnostic.Diagnostic{{Message: fmt.Sprintf("found matching serviceAccount (%q)", sa)}}
				}
diff --git a/pkg/templates/util/required_matcher.go b/pkg/templates/util/required_matcher.go
index ff51978..56029f2 100644
--- a/pkg/templates/util/required_matcher.go
+++ b/pkg/templates/util/required_matcher.go
@@ -42,7 +42,7 @@ func ConstructRequiredMapMatcher(key, value, fieldType string) (check.Func, erro
			}
		}
		return []diagnostic.Diagnostic{{
			Message: fmt.Sprintf("no %s matching \"%s=%s\" found", fieldType, key, [-stringutils.OrDefault(value,-]{+stringutils.OrFallback(value,+} "<any>")),
		}}
	}, nil
}
```
</details>

<details><summary>similarity</summary>

`git show HEAD~ -M1 -U0 --oneline`:
```diff
a788700 spelling: fallback
diff --git a/internal/stringutils/default.go b/internal/stringutils/fallback.go
similarity index 18%
rename from internal/stringutils/default.go
rename to internal/stringutils/fallback.go
index 1cc03b8..60617d2 100644
--- a/internal/stringutils/default.go
+++ b/internal/stringutils/fallback.go
@@ -3,2 +3,2 @@ package stringutils
-// OrDefault returns the string if it's not empty, or the default.
-func OrDefault(s, defaul string) string {
+// OrFallback returns the string if it's not empty, or the fallback.
+func OrFallback(s, fallback string) string {
@@ -8 +8 @@ func OrDefault(s, defaul string) string {
-	return defaul
+	return fallback
@@ -11,2 +11,2 @@ func OrDefault(s, defaul string) string {
-// PointerOrDefault returns the string if it's not nil nor empty, or the default.
-func PointerOrDefault(s *string, defaul string) string {
+// PointerOrFallback returns the string if it's not nil nor empty, or the fallback.
+func PointerOrFallback(s *string, fallback string) string {
@@ -14 +14 @@ func PointerOrDefault(s *string, defaul string) string {
-		return defaul
+		return fallback
@@ -17 +17 @@ func PointerOrDefault(s *string, defaul string) string {
-	return OrDefault(*s, defaul)
+	return OrFallback(*s, fallback)
diff --git a/internal/version/version.go b/internal/version/version.go
index a6aa2aa..b18a790 100644
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -13 +13 @@ func Get() string {
-	return stringutils.OrDefault(version, "development")
+	return stringutils.OrFallback(version, "development")
diff --git a/pkg/diagnostic/diagnostic.go b/pkg/diagnostic/diagnostic.go
index db8d5f5..dd34028 100644
--- a/pkg/diagnostic/diagnostic.go
+++ b/pkg/diagnostic/diagnostic.go
@@ -36 +36 @@ func formatObj(obj k8sutil.Object) string {
-	return fmt.Sprintf("%s/%s %s", stringutils.OrDefault(obj.GetNamespace(), "<no namespace>"), obj.GetName(), obj.GetObjectKind().GroupVersionKind())
+	return fmt.Sprintf("%s/%s %s", stringutils.OrFallback(obj.GetNamespace(), "<no namespace>"), obj.GetName(), obj.GetObjectKind().GroupVersionKind())
diff --git a/pkg/templates/nonexistentserviceaccount/template.go b/pkg/templates/nonexistentserviceaccount/template.go
index 668c454..f61929b 100644
--- a/pkg/templates/nonexistentserviceaccount/template.go
+++ b/pkg/templates/nonexistentserviceaccount/template.go
@@ -39 +39 @@ func init() {
-				sa := stringutils.OrDefault(podSpec.ServiceAccountName, podSpec.DeprecatedServiceAccount)
+				sa := stringutils.OrFallback(podSpec.ServiceAccountName, podSpec.DeprecatedServiceAccount)
diff --git a/pkg/templates/serviceaccount/template.go b/pkg/templates/serviceaccount/template.go
index 5229074..e2531cc 100644
--- a/pkg/templates/serviceaccount/template.go
+++ b/pkg/templates/serviceaccount/template.go
@@ -38 +38 @@ func init() {
-				sa := stringutils.OrDefault(podSpec.ServiceAccountName, podSpec.DeprecatedServiceAccount)
+				sa := stringutils.OrFallback(podSpec.ServiceAccountName, podSpec.DeprecatedServiceAccount)
diff --git a/pkg/templates/util/required_matcher.go b/pkg/templates/util/required_matcher.go
index ff51978..56029f2 100644
--- a/pkg/templates/util/required_matcher.go
+++ b/pkg/templates/util/required_matcher.go
@@ -45 +45 @@ func ConstructRequiredMapMatcher(key, value, fieldType string) (check.Func, erro
-			Message: fmt.Sprintf("no %s matching \"%s=%s\" found", fieldType, key, stringutils.OrDefault(value, "<any>")),
+			Message: fmt.Sprintf("no %s matching \"%s=%s\" found", fieldType, key, stringutils.OrFallback(value, "<any>")),
```
</details>