### PR TITLE
Make sure lint checks appear in GitHub Pull Request UI

### DIFF
--- a/.github/workflows/test-sarif.yaml
+++ b/.github/workflows/test-sarif.yaml
@@ -1,7 +1,16 @@
 name: Test kube-linter SARIF output
 
 on:
-  - push
+  # Important! Event type should be (or include) `pull_request` if you want to see linter checks in pull request UI.
+  #
+  # `github/codeql-action/upload-sarif@v1` action seems to use `${{ github.ref }}` context property when it submits
+  # SARIF through the API.
+  # When `github.ref` points to the branch, sarif results appear only in the security tab. When `github.ref` points to
+  # PR, results will appear also in the PR UI.
+  # See info here https://docs.github.com/en/rest/reference/code-scanning#upload-an-analysis-as-sarif-data
+  # Although not documented officially, `pull_request` event type will make `github.ref` in PR format.
+  # See https://frontside.com/blog/2020-05-26-github-actions-pull_request/#how-does-pull_request-affect-actionscheckout
+  - pull_request
 
 jobs:
   build-and-test:

--- a/tests/testdata/splunk.yaml
+++ b/tests/testdata/splunk.yaml
@@ -36,6 +36,8 @@ spec:
       containers:
         - name: splunk
           image: splunk/splunk:8.1.2
+          securityContext:
+            privileged: true
           ports:
             - containerPort: 8000
             - containerPort: 8088


### PR DESCRIPTION
Turns out there's a way to see lint results in PR UI, not only in Security tab.
![image](https://user-images.githubusercontent.com/537715/116608767-deb8a080-a933-11eb-9d06-917f6783ff8c.png)

This behavior isn't very well documented and wouldn't work out of the box for `push` event type (like it did not originally). In that case users should consider something like this action to find out PR number: https://github.com/marketplace/actions/find-current-pull-request. Next, it should be put in `github.ref`, but that's beyond my today's investigation capacity.

Many thanks to @misberner for being persistent and showing me [an example](https://github.com/LearnLib/alex/pull/101/files) that it is indeed possible to have lint errors in PR view.