### PR TITLE
Enable `push` trigger so that GitHub diffs alerts

### DIFF
--- a/.github/workflows/test-sarif.yaml
+++ b/.github/workflows/test-sarif.yaml
@@ -11,6 +11,9 @@ on:
   # Although not documented officially, `pull_request` event type will make `github.ref` in PR format.
   # See https://frontside.com/blog/2020-05-26-github-actions-pull_request/#how-does-pull_request-affect-actionscheckout
   - pull_request
+  # `push` event type should also be turned on in order for GitHub to be able to figure out diff between alerts in
+  # source and target branches of PR and display it in Actions | Code scanning results.
+  - push
 
 jobs:
   build-and-test:


### PR DESCRIPTION
GitHub did not show alerts diff after my last change https://github.com/stackrox/kube-linter/pull/165.
See https://github.com/stackrox/kube-linter/pull/166/checks?check_run_id=2473434039
![image](https://user-images.githubusercontent.com/537715/116671460-3e996080-a9a1-11eb-8582-4adb5fabc711.png)

There was no code scanning for the _recent_ `refs/heads/main` because I turned off `push` trigger and scanning only happened for PRs.
I hope that restoring `push` trigger in addition to `pull_request` will give us full visibility into scan alerts in all spots they should be displayed.

A bit annoying side effect is that scanning will be done two times now, once for each trigger, when PR is created/updated. We _could_ deal with it by refactoring GitHub workflow and splitting it into two parts: the one does only _build binaries_ and is triggered on `push`. The other workflow uses built binaries and and _performs scan_ on _both_ `push` and `pull_request` events.
I've tried split workflow with separate build and scan jobs while working on the previous PR. It is possible but adds more complexity. I think, it is not worth doing so at this point.

Testing done:
* https://github.com/stackrox/kube-linter/runs/2474286900
* https://github.com/stackrox/kube-linter/pull/168