### PR TITLE
Fixed bad link

### DIFF
--- a/docs/configuring-kubelinter.md
+++ b/docs/configuring-kubelinter.md
@@ -131,7 +131,7 @@ For example,
           - DeploymentLike
   ```
 
-  For details about `objectKinds` that KubeLinter support, see https://github.com/stackrox/kube-linter/tree/main/internal/objectkinds
+  For details about `objectKinds` that KubeLinter support, see https://github.com/stackrox/kube-linter/tree/main/pkg/objectkinds.
 
 - Use `remediation` to include a remediation message that users get when your custom check fails:
   ```yaml


### PR DESCRIPTION
Based on https://kube-linter.slack.com/archives/C01ASRW6Y8L/p1620828189029700

> link to supported objectKinds is incorrect. https://github.com/stackrox/kube-linter/tree/main/internal/objectkinds gives a 404.
> we need to update that link. It should be https://github.com/stackrox/kube-linter/tree/main/pkg/objectkinds. (cc: @Gaurav )