### PR TITLE
add allowlist parameter to the exisiting latestTag check

### DIFF
--- a/docs/generated/checks.md
+++ b/docs/generated/checks.md
@@ -214,9 +214,9 @@ KubeLinter includes the following built-in checks:
 
 **Enabled by default**: Yes
 
-**Description**: Indicates when a deployment-like object is running a container with a floating image tag, "latest"
+**Description**: Indicates when a deployment-like object is running a container with an invalid container image
 
-**Remediation**: Use a container image with a proper image tag, outside the set blocked tag regex ".*:(latest)$".
+**Remediation**: Use a container image with a proper image tag satisfying either the "AllowList" & "BlockList" regex patterns.
 
 **Template**: [latest-tag](generated/templates.md#latest-tag)
 

--- a/docs/generated/templates.md
+++ b/docs/generated/templates.md
@@ -322,7 +322,7 @@ KubeLinter supports the following templates:
 
 **Key**: `latest-tag`
 
-**Description**: Flag applications running containers with floating container image tag, "latest"
+**Description**: Flag applications running container images that do not satisfies "allowList" & "blockList" parameters criteria.
 
 **Supported Objects**: DeploymentLike
 
@@ -333,7 +333,16 @@ KubeLinter supports the following templates:
   {
     "name": "blockList",
     "type": "array",
-    "description": "list of regular expressions for blocked or bad container image tags",
+    "description": "list of regular expressions specifying pattern(s) for container images that will be blocked. */",
+    "required": false,
+    "regexAllowed": true,
+    "negationAllowed": true,
+    "arrayElemType": "string"
+  },
+  {
+    "name": "allowList",
+    "type": "array",
+    "description": "list of regular expressions specifying pattern(s) for container images that will be allowed.",
     "required": false,
     "regexAllowed": true,
     "negationAllowed": true,

--- a/pkg/builtinchecks/yamls/latest-tag.yaml
+++ b/pkg/builtinchecks/yamls/latest-tag.yaml
@@ -1,9 +1,9 @@
 name: "latest-tag"
-description: "Indicates when a deployment-like object is running a container with a floating image tag, \"latest\""
-remediation: "Use a container image with a proper image tag, outside the set blocked tag regex \".*:(latest)$\"."
+description: "Indicates when a deployment-like object is running a container with an invalid container image"
+remediation: "Use a container image with a proper image tag satisfying either the \"AllowList\" & \"BlockList\" regex patterns."
 scope:
   objectKinds:
     - DeploymentLike
 template: "latest-tag"
 params:
-  BlockList: [".*:(latest)$" ]
+  BlockList: [".*:(latest)$"]

--- a/pkg/templates/latesttag/internal/params/gen-params.go
+++ b/pkg/templates/latesttag/internal/params/gen-params.go
@@ -20,7 +20,7 @@ var (
 	blockListParamDesc = util.MustParseParameterDesc(`{
 	"Name": "blockList",
 	"Type": "array",
-	"Description": "list of regular expressions for blocked or bad container image tags",
+	"Description": "list of regular expressions specifying pattern(s) for container images that will be blocked. */",
 	"Examples": null,
 	"Enum": null,
 	"SubParameters": null,
@@ -33,8 +33,25 @@ var (
 }
 `)
 
+	allowListParamDesc = util.MustParseParameterDesc(`{
+	"Name": "allowList",
+	"Type": "array",
+	"Description": "list of regular expressions specifying pattern(s) for container images that will be allowed.",
+	"Examples": null,
+	"Enum": null,
+	"SubParameters": null,
+	"ArrayElemType": "string",
+	"Required": false,
+	"NoRegex": false,
+	"NotNegatable": false,
+	"XXXStructFieldName": "AllowList",
+	"XXXIsPointer": false
+}
+`)
+
 	ParamDescs = []check.ParameterDesc{
 		blockListParamDesc,
+		allowListParamDesc,
 	}
 )
 

--- a/pkg/templates/latesttag/internal/params/params.go
+++ b/pkg/templates/latesttag/internal/params/params.go
@@ -3,6 +3,9 @@ package params
 // Params represents the params accepted by this template.
 type Params struct {
 
-	// list of regular expressions for blocked or bad container image tags
+	// list of regular expressions specifying pattern(s) for container images that will be blocked. */
 	BlockList []string
+
+	// list of regular expressions specifying pattern(s) for container images that will be allowed.
+	AllowList []string
 }

--- a/pkg/templates/latesttag/template.go
+++ b/pkg/templates/latesttag/template.go
@@ -23,7 +23,7 @@ func init() {
 	templates.Register(check.Template{
 		HumanName:   "Latest Tag",
 		Key:         templateKey,
-		Description: "Flag applications running containers with floating container image tag, \"latest\"",
+		Description: "Flag applications running container images that do not satisfies \"allowList\" & \"blockList\" parameters criteria.",
 		SupportedObjectKinds: config.ObjectKindsDesc{
 			ObjectKinds: []string{objectkinds.DeploymentLike},
 		},
@@ -40,6 +40,20 @@ func init() {
 				blockedRegexes = append(blockedRegexes, rg)
 			}
 
+			allowedRegexes := make([]*regexp.Regexp, 0, len(p.AllowList))
+			for _, res := range p.AllowList {
+				rg, err := regexp.Compile(res)
+				if err != nil {
+					return nil, errors.Wrapf(err, "invalid regex %s", res)
+				}
+				allowedRegexes = append(allowedRegexes, rg)
+			}
+
+			if len(blockedRegexes) > 0 && len(allowedRegexes) > 0 {
+				err := fmt.Errorf("check has both \"allowList\" & \"blockList\" parameter's values set")
+				return nil, errors.Wrapf(err, "Only one of the paramater lists can be used at a time.")
+			}
+
 			return func(_ lintcontext.LintContext, object lintcontext.Object) []diagnostic.Diagnostic {
 				podSpec, found := extract.PodSpec(object.K8sObject)
 				if !found {
@@ -49,14 +63,13 @@ func init() {
 				var results []diagnostic.Diagnostic
 
 				for _, container := range podSpec.Containers {
-					if isInList(blockedRegexes, container.Image) {
-						results = append(results, diagnostic.Diagnostic{Message: fmt.Sprintf("The container %q is using a floating image tag, %q.", container.Name, container.Image)})
+					if len(blockedRegexes) > 0 && isInList(blockedRegexes, container.Image) {
+						results = append(results, diagnostic.Diagnostic{Message: fmt.Sprintf("The container %q is using an invalid container image, %q. Please use images that are not blocked by the `BlockList` criteria : %q", container.Name, container.Image, blockedRegexes)})
+					} else if len(allowedRegexes) > 0 && !isInList(allowedRegexes, container.Image) {
+						results = append(results, diagnostic.Diagnostic{Message: fmt.Sprintf("The container %q is using an invalid container image, %q. Please use images that satisfies the `AllowList` criteria : %q", container.Name, container.Image, allowedRegexes)})
 					}
-
 				}
-
 				return results
-
 			}, nil
 		}),
 	})


### PR DESCRIPTION
The PR does the following:

- Add another parameter `AllowList` to the check with a default value equals to empty list 
- Improve the existing check logic to validate that the check has either `AllowList` or `BlockList` set or both set and then action properly.