### PR TITLE
Return non-zero exit status on no valid objects

### DIFF
--- a/e2etests/sanity_test.go
+++ b/e2etests/sanity_test.go
@@ -1,13 +1,16 @@
+//go:build e2e
 // +build e2e
 
 package e2etests
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,4 +51,30 @@ func TestKubeLinterWithBuiltInChecksDoesntCrashOnHelmChartsRepo(t *testing.T) {
 	outAsStr := string(kubeLinterOut)
 	assert.Equal(t, 1, exitErr.ExitCode(), "unexpected exit code: %d; output from kube-linter: %v", exitErr.ExitCode(), outAsStr)
 	assert.True(t, expectedOutRegex.MatchString(outAsStr), "unexpected output: %s", outAsStr)
+}
+
+func TestKubeLinterExitsWithNonZeroCodeOnEmptyDir(t *testing.T) {
+	kubeLinterBin := os.Getenv(kubeLinterBinEnv)
+
+	tmpDir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.RemoveAll(tmpDir))
+	}()
+	kubeLinterOut, err := exec.Command(kubeLinterBin, "lint", tmpDir, "--fail-if-no-objects-found").CombinedOutput()
+
+	// error is expected
+	require.Error(t, err)
+	exitErr, ok := err.(*exec.ExitError)
+	require.True(t, ok)
+	outAsStr := string(kubeLinterOut)
+	assert.Equal(t, 1, exitErr.ExitCode(), "unexpected exit code: %d; output from kube-linter: %v", exitErr.ExitCode(), outAsStr)
+	msg := "no valid objects found"
+	assert.True(t, strings.Contains(outAsStr, fmt.Sprintf("Error: %s", msg)), "unexpected output, it should contain: %s", outAsStr)
+
+	// without the switch only warning is printed to stderr
+	kubeLinterOut, err = exec.Command(kubeLinterBin, "lint", tmpDir).CombinedOutput()
+	require.NoError(t, err)
+	outAsStr = string(kubeLinterOut)
+	assert.True(t, strings.Contains(outAsStr, fmt.Sprintf("Warning: %s", msg)), "unexpected output, it should contain: %s", outAsStr)
 }

--- a/pkg/command/lint/command.go
+++ b/pkg/command/lint/command.go
@@ -95,8 +95,7 @@ func Command() *cobra.Command {
 				}
 			}
 			if !atLeastOneObjectFound {
-				fmt.Fprintln(os.Stderr, "Warning: no valid objects found.")
-				return nil
+				return errors.New("no valid objects found")
 			}
 			result, err := run.Run(lintCtxs, checkRegistry, enabledChecks)
 			if err != nil {

--- a/pkg/command/lint/command.go
+++ b/pkg/command/lint/command.go
@@ -44,6 +44,7 @@ var (
 // Command is the command for the lint command.
 func Command() *cobra.Command {
 	var configPath string
+	var failIfNoObjects bool
 	var verbose bool
 	format := flagutil.NewEnumFlag("Output format", formatters.GetEnabledFormatters(), common.PlainFormat)
 
@@ -95,7 +96,12 @@ func Command() *cobra.Command {
 				}
 			}
 			if !atLeastOneObjectFound {
-				return errors.New("no valid objects found")
+				msg := "no valid objects found"
+				if failIfNoObjects {
+					return errors.New(msg)
+				}
+				fmt.Fprintf(os.Stderr, "Warning: %s.\n", msg)
+				return nil
 			}
 			result, err := run.Run(lintCtxs, checkRegistry, enabledChecks)
 			if err != nil {
@@ -119,6 +125,7 @@ func Command() *cobra.Command {
 	}
 
 	c.Flags().StringVar(&configPath, "config", "", "Path to config file")
+	c.Flags().BoolVarP(&failIfNoObjects, "fail-if-no-objects-found", "", false, "Return non-zero exit code if no valid objects are found or failed to parse")
 	c.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
 	c.Flags().Var(format, "format", format.Usage())
 


### PR DESCRIPTION
Instead of printing the warning and return 0 exit status
return Error and exit with 1

Reasoning: our kube-linter pipelines where silently failing
for a while without any notice because of 0 exit status

See https://github.com/k8gb-io/k8gb/pull/615#issuecomment-918000074

Signed-off-by: Yury Tsarev <yury.tsarev@absa.africa>