### PR TITLE
'deprecated-service-account-field' should pass if both 'serviceAccount' and 'serviceAccountName' are set

### DIFF
--- a/docs/generated/checks.md
+++ b/docs/generated/checks.md
@@ -88,7 +88,7 @@ KubeLinter includes the following built-in checks:
 
 **Description**: Indicates when deployments use the deprecated serviceAccount field.
 
-**Remediation**: Use the serviceAccountName field instead.
+**Remediation**: Use the serviceAccountName field instead. If you must specify serviceAccount, ensure values for serviceAccount and serviceAccountName match.
 
 **Template**: [deprecated-service-account-field](generated/templates.md#deprecated-service-account-field)
 

--- a/pkg/builtinchecks/yamls/deprecated-service-account.yaml
+++ b/pkg/builtinchecks/yamls/deprecated-service-account.yaml
@@ -1,6 +1,6 @@
 name: "deprecated-service-account-field"
 description: "Indicates when deployments use the deprecated serviceAccount field."
-remediation: "Use the serviceAccountName field instead."
+remediation: "Use the serviceAccountName field instead. If you must specify serviceAccount, ensure values for serviceAccount and serviceAccountName match."
 scope:
   objectKinds:
     - DeploymentLike

--- a/pkg/templates/deprecatedserviceaccount/template.go
+++ b/pkg/templates/deprecatedserviceaccount/template.go
@@ -36,10 +36,10 @@ func init() {
 					if san == "" { // only serviceAccount is specified
 						return []diagnostic.Diagnostic{{Message: fmt.Sprintf(
 							"serviceAccount is specified (%s), but this field is deprecated; use serviceAccountName instead", sa)}}
-					} else { // serviceAccount and serviceAccountName both specified but do not match
-						return []diagnostic.Diagnostic{{Message: fmt.Sprintf(
-							"serviceAccount (%s) and serviceAccountName (%s) are both specified with non-matching values. serviceAccount is deprecated; unspecify serviceAccount or make values match.", sa, san)}}
 					}
+					// serviceAccount and serviceAccountName both specified but do not match
+					return []diagnostic.Diagnostic{{Message: fmt.Sprintf(
+						"serviceAccount (%s) and serviceAccountName (%s) are both specified with non-matching values. serviceAccount is deprecated; unspecify serviceAccount or make values match.", sa, san)}}
 				}
 				return nil
 			}, nil

--- a/pkg/templates/deprecatedserviceaccount/template.go
+++ b/pkg/templates/deprecatedserviceaccount/template.go
@@ -29,9 +29,17 @@ func init() {
 				if !found {
 					return nil
 				}
-				if sa := podSpec.DeprecatedServiceAccount; sa != "" {
-					return []diagnostic.Diagnostic{{Message: fmt.Sprintf(
-						"serviceAccount is specified (%s), but this field is deprecated; use serviceAccountName instead", sa)}}
+
+				sa := podSpec.DeprecatedServiceAccount
+				san := podSpec.ServiceAccountName
+				if sa != "" && sa != san {
+					if san == "" { // only serviceAccount is specified
+						return []diagnostic.Diagnostic{{Message: fmt.Sprintf(
+							"serviceAccount is specified (%s), but this field is deprecated; use serviceAccountName instead", sa)}}
+					} else { // serviceAccount and serviceAccountName both specified but do not match
+						return []diagnostic.Diagnostic{{Message: fmt.Sprintf(
+							"serviceAccount (%s) and serviceAccountName (%s) are both specified with non-matching values. serviceAccount is deprecated; unspecify serviceAccount or make values match.", sa, san)}}
+					}
 				}
 				return nil
 			}, nil


### PR DESCRIPTION
Resolves: #217 

Updates the 'deprecated-service-account-field' check to pass if either of the two conditions are met:
* serviceAccount not set at all (this is the only valid condition prior to this PR)
* serviceAccount and serviceAccountName are both set, and have matching values (new condition)

Output messages are updated as appropriate.