### PR TITLE
Fix Helm object paths, take two

### DIFF
--- a/pkg/lintcontext/create_contexts.go
+++ b/pkg/lintcontext/create_contexts.go
@@ -115,6 +115,8 @@ func CreateContextsWithOptions(options Options, filesOrDirs ...string) ([]LintCo
 }
 
 // CreateContextsFromHelmArchive creates a context from TGZ reader of Helm Chart.
+// Note: although this function is not used in CLI, it is exposed from kube-linter library and therefore should stay.
+// See https://github.com/stackrox/kube-linter/pull/173
 func CreateContextsFromHelmArchive(fileName string, tgzReader io.Reader) ([]LintContext, error) {
 	ctx := newCtx(Options{})
 	ctx.readObjectsFromTgzHelmChart(fileName, tgzReader)

--- a/pkg/lintcontext/create_contexts_test.go
+++ b/pkg/lintcontext/create_contexts_test.go
@@ -1,34 +1,94 @@
 package lintcontext
 
 import (
+	"fmt"
 	"os"
+	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-const chartTarball = "../../tests/testdata/mychart-0.1.0.tgz"
+const (
+	chartTarball    = "../../tests/testdata/mychart-0.1.0.tgz"
+	chartDirectory  = "../../tests/testdata/mychart"
+	renamedTarball  = "../../tests/testdata/my-renamed-chart-0.1.0.tgz"
+	renamedChartDir = "../../tests/testdata/my-renamed-chart"
+	mockPath        = "mock path"
+)
 
-func TestCreateContextsFromHelmArchive(t *testing.T) {
-	file, err := os.Open(chartTarball)
-	require.NoError(t, err)
+func TestCreateContextsObjectPaths(t *testing.T) {
+	bools := []bool{false, true}
 
-	defer func() {
-		require.NoError(t, file.Close())
-	}()
+	for _, useTarball := range bools {
+		for _, absolute := range bools {
+			for _, rename := range bools {
+				for _, useFromArchiveFunction := range bools {
+					// CreateContextsFromHelmArchive can only be used with tarballs
+					if useFromArchiveFunction && !useTarball {
+						continue
+					}
 
-	lintCtxs, err := CreateContextsFromHelmArchive("test", file)
-	require.NoError(t, err)
-
-	assert.NotNil(t, verifyAndGetContext(t, lintCtxs))
+					testName := fmt.Sprintf("tarball %t, absolute path %t, rename %t, use from archive function %t", useTarball, absolute, rename, useFromArchiveFunction)
+					t.Run(testName, func(t *testing.T) {
+						createContextsAndVerifyPaths(t, useTarball, absolute, rename, useFromArchiveFunction)
+					})
+				}
+			}
+		}
+	}
 }
 
-func TestCreateContexts_WithHelmArchive(t *testing.T) {
-	lintCtxs, err := CreateContexts(chartTarball)
+func createContextsAndVerifyPaths(t *testing.T, useTarball, useAbsolutePath, rename, useFromArchiveFunction bool) {
+	var err error
+
+	// Arrange
+	relativePath := map[bool]string{false: chartDirectory, true: chartTarball}[useTarball]
+	renamedPath := map[bool]string{false: renamedChartDir, true: renamedTarball}[useTarball]
+
+	testPath := relativePath
+
+	if rename {
+		testPath = renamedPath
+		require.NoError(t, os.Rename(relativePath, renamedPath))
+		defer func() {
+			assert.NoError(t, os.Rename(renamedPath, relativePath))
+		}()
+	}
+
+	if useAbsolutePath {
+		testPath, err = filepath.Abs(testPath)
+		require.NoError(t, err)
+	}
+
+	// Act. The code actually tests either of functions: CreateContextsFromHelmArchive and CreateContexts
+	var lintCtxs []LintContext
+	if useFromArchiveFunction {
+		var file *os.File
+		file, err = os.Open(testPath)
+		require.NoError(t, err)
+
+		defer func() {
+			require.NoError(t, file.Close())
+		}()
+
+		lintCtxs, err = CreateContextsFromHelmArchive(mockPath, file)
+	} else {
+		lintCtxs, err = CreateContexts(testPath)
+	}
 	require.NoError(t, err)
 
-	assert.NotNil(t, verifyAndGetContext(t, lintCtxs))
+	// Assert
+	expectedPath := testPath
+	if useTarball {
+		expectedPath = path.Join(expectedPath, "mychart")
+	}
+	if useFromArchiveFunction {
+		expectedPath = path.Join(mockPath, "mychart")
+	}
+	checkObjectPaths(t, verifyAndGetContext(t, lintCtxs).Objects(), expectedPath)
 }
 
 func verifyAndGetContext(t *testing.T, lintCtxs []LintContext) LintContext {
@@ -39,4 +99,18 @@ func verifyAndGetContext(t *testing.T, lintCtxs []LintContext) LintContext {
 	assert.Empty(t, lintCtx.InvalidObjects(), "no invalid objects expected")
 
 	return lintCtx
+}
+
+func checkObjectPaths(t *testing.T, objects []Object, expectedPrefix string) {
+	actualPaths := make([]string, 0, len(objects))
+	for _, obj := range objects {
+		actualPaths = append(actualPaths, obj.Metadata.FilePath)
+	}
+	expectedPaths := []string{
+		path.Join(expectedPrefix, "templates/deployment.yaml"),
+		path.Join(expectedPrefix, "templates/service.yaml"),
+		path.Join(expectedPrefix, "templates/serviceaccount.yaml"),
+		path.Join(expectedPrefix, "templates/tests/test-connection.yaml"),
+	}
+	assert.ElementsMatchf(t, expectedPaths, actualPaths, "expected and actual template paths don't match")
 }

--- a/tests/testdata/mychart/.helmignore
+++ b/tests/testdata/mychart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/tests/testdata/mychart/Chart.yaml
+++ b/tests/testdata/mychart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: 1.16.0
+description: A Helm chart for Kubernetes
+name: mychart
+type: application
+version: 0.1.0

--- a/tests/testdata/mychart/templates/NOTES.txt
+++ b/tests/testdata/mychart/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "mychart.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "mychart.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "mychart.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "mychart.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/tests/testdata/mychart/templates/_helpers.tpl
+++ b/tests/testdata/mychart/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mychart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mychart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mychart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mychart.labels" -}}
+helm.sh/chart: {{ include "mychart.chart" . }}
+{{ include "mychart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mychart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mychart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mychart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mychart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/tests/testdata/mychart/templates/deployment.yaml
+++ b/tests/testdata/mychart/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mychart.fullname" . }}
+  labels:
+    {{- include "mychart.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "mychart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "mychart.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "mychart.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/tests/testdata/mychart/templates/hpa.yaml
+++ b/tests/testdata/mychart/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "mychart.fullname" . }}
+  labels:
+    {{- include "mychart.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "mychart.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/tests/testdata/mychart/templates/ingress.yaml
+++ b/tests/testdata/mychart/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "mychart.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "mychart.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/tests/testdata/mychart/templates/service.yaml
+++ b/tests/testdata/mychart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mychart.fullname" . }}
+  labels:
+    {{- include "mychart.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "mychart.selectorLabels" . | nindent 4 }}

--- a/tests/testdata/mychart/templates/serviceaccount.yaml
+++ b/tests/testdata/mychart/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mychart.serviceAccountName" . }}
+  labels:
+    {{- include "mychart.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/tests/testdata/mychart/templates/tests/test-connection.yaml
+++ b/tests/testdata/mychart/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "mychart.fullname" . }}-test-connection"
+  labels:
+    {{- include "mychart.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "mychart.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/tests/testdata/mychart/values.yaml
+++ b/tests/testdata/mychart/values.yaml
@@ -1,0 +1,79 @@
+# Default values for mychart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
## Description

This addresses https://github.com/stackrox/kube-linter/issues/212
This supersedes https://github.com/stackrox/kube-linter/pull/215

## Testing

* Relying on CI.
* Verified on the example from the issue #212 
```bash
$ make build
$ .gobin/kube-linter lint my-helm-chart-directory --format sarif \
  | jq -r '.runs[].results[].locations[].physicalLocation.artifactLocation.uri'
Error: found 12 lint errors
my-helm-chart-directory/templates/tests/test-connection.yaml
my-helm-chart-directory/templates/tests/test-connection.yaml
my-helm-chart-directory/templates/tests/test-connection.yaml
my-helm-chart-directory/templates/tests/test-connection.yaml
my-helm-chart-directory/templates/tests/test-connection.yaml
my-helm-chart-directory/templates/tests/test-connection.yaml
my-helm-chart-directory/templates/deployment.yaml
my-helm-chart-directory/templates/deployment.yaml
my-helm-chart-directory/templates/deployment.yaml
my-helm-chart-directory/templates/deployment.yaml
my-helm-chart-directory/templates/deployment.yaml
my-helm-chart-directory/templates/deployment.yaml
```