### PR TITLE
fix command name for shell completion

### DIFF
--- a/pkg/command/root/command.go
+++ b/pkg/command/root/command.go
@@ -2,6 +2,7 @@ package root
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"golang.stackrox.io/kube-linter/pkg/command/checks"
@@ -13,7 +14,7 @@ import (
 // Command is the root command.
 func Command() *cobra.Command {
 	c := &cobra.Command{
-		Use:           os.Args[0],
+		Use:           filepath.Base(os.Args[0]),
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}


### PR DESCRIPTION
Hello.
This is PR for fixing `kube-linter completion` subcommand for generating shell completion script, that is provided by cobra.

kube-linter currently uses `arg[0]` as command name.
That causes making invalid shell completion script.

If kube-linter is invoked using full path such as `/usr/local/bin/kube-linter completion zsh`, it generates 

```
#compdef _/usr/local/bin/kube-linter /usr/local/bin/kube-linter

# zsh completion for /usr/local/bin/kube-linter           -*- shell-script -*-

__/usr/local/bin/kube-linter_debug()
{
    local file="$BASH_COMP_DEBUG_FILE"
...
```

Bu it should be 
```
#compdef _kube-linter kube-linter

# zsh completion for kube-linter                          -*- shell-script -*-

__kube-linter_debug()
{
    local file="$BASH_COMP_DEBUG_FILE"
    if [[ -n ${file} ]]; then
        echo "$*" >> "${file}"
    fi
```