### PR TITLE
Use `go install` for installing binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Visit https://docs.kubelinter.io for detailed documentation on installing, using
 To install using [Go](https://golang.org/), run the following command:
 
 ```bash
-GO111MODULE=on go get golang.stackrox.io/kube-linter/cmd/kube-linter
+GO111MODULE=on go install golang.stackrox.io/kube-linter/cmd/kube-linter
 ```
 Otherwise, download the latest binary from [Releases](https://github.com/stackrox/kube-linter/releases) and add it to your
 PATH.

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ for resolving any potential issues and returns a non-zero exit code.
 To install by using [Go](https://golang.org/), run the following command:
 
 ```bash
-GO111MODULE=on go get golang.stackrox.io/kube-linter/cmd/kube-linter
+GO111MODULE=on go install golang.stackrox.io/kube-linter/cmd/kube-linter
 ```
 Otherwise, download the latest binary from
 [Releases](https://github.com/stackrox/kube-linter/releases) and add it to your


### PR DESCRIPTION
As noted in [0], `go get` is deprecated for installing binaries,
therefore we should update our documentation to prevent unnecessary
warnings for consumers of this project.

[0]: https://golang.org/doc/go-get-install-deprecation
