### PR TITLE
added integration tests via bats-core

### DIFF
--- a/.github/workflows/bats-e2e.yaml
+++ b/.github/workflows/bats-e2e.yaml
@@ -1,0 +1,44 @@
+name: Test kube-linter via BATS
+
+on:
+  - pull_request
+  - push
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Checkout all repo history to make tags available for figuring out kube-linter version during build.
+          fetch-depth: 0
+
+      - name: Read Go version from go.mod
+        run: echo "GO_VERSION=$(grep -E "^go\s+[0-9.]+$" go.mod | cut -d " " -f 2)" >> $GITHUB_ENV
+
+      - name: Setup Go environment
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Cache Go modules
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Build binaries
+        run: make build
+
+      - name: Print kube-linter version
+        run: .gobin/kube-linter version
+
+      - name: Setup BATS
+        uses: mig4/setup-bats@v1
+        with:
+          bats-version: 1.5.0
+
+      - name: Run bats tests
+        run: make e2e-bats

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 # Empty file touched by `make deps`
 /deps
 
+e2etests/test_helper

--- a/Makefile
+++ b/Makefile
@@ -108,3 +108,11 @@ test:
 e2e-test: $(KUBE_LINTER_BIN)
 	KUBE_LINTER_BIN="$(KUBE_LINTER_BIN)" go test -tags e2e -count=1 ./e2etests/...
 
+.PHONY: e2e-bats
+e2e-bats: $(KUBE_LINTER_BIN)
+	@command -v jq &> /dev/null || { echo >&2 'ERROR: jq not installed; See: https://stedolan.github.io/jq/download - Aborting'; exit 1; }
+	@command -v diff &> /dev/null || { echo >&2 'ERROR: diff not installed; See: https://www.baeldung.com/linux/diff-command - Aborting'; exit 1; }
+	@command -v bats &> /dev/null || { echo >&2 'ERROR: bats not installed; See: https://bats-core.readthedocs.io/en/stable/installation.html - Aborting'; exit 1; }
+
+	KUBE_LINTER_BIN="$(KUBE_LINTER_BIN)" e2etests/bats-tests.sh
+	KUBE_LINTER_BIN="$(KUBE_LINTER_BIN)" e2etests/check-bats-tests.sh

--- a/README.md
+++ b/README.md
@@ -63,6 +63,27 @@ Installing KubeLinter from source is as simple as following these steps:
    .gobin/kube-linter version
    ```
 
+### Testing KubeLinter
+There are several layers of testing. Each layer is expected to pass.
+
+1. `go` unit tests:
+
+   ```bash
+   make test
+   ```
+
+2. end-to-end integration tests:
+
+   ```bash
+   make e2e-test
+   ```
+
+3. and finally, end-to-end integration tests using `bats-core`:
+
+   ```bash
+   make e2e-bats
+   ```
+
 ## Using KubeLinter
 
 ### Local YAML Linting

--- a/e2etests/bats-support-clone.bash
+++ b/e2etests/bats-support-clone.bash
@@ -1,0 +1,9 @@
+if [[ ! -d "e2etests/test_helper/bats-support" ]]; then
+  # Download bats-support dynamically so it doesnt need to be added into source
+  git clone https://github.com/ztombol/bats-support e2etests/test_helper/bats-support --depth 1
+fi
+
+if [[ ! -d "e2etests/test_helper/redhatcop-bats-library" ]]; then
+  # Download redhat-cop/bats-library dynamically so it doesnt need to be added into source
+  git clone https://github.com/redhat-cop/bats-library e2etests/test_helper/redhatcop-bats-library --depth 1
+fi

--- a/e2etests/bats-tests.sh
+++ b/e2etests/bats-tests.sh
@@ -1,0 +1,726 @@
+#!/usr/bin/env bats
+
+load bats-support-clone
+load test_helper/bats-support/load
+load test_helper/redhatcop-bats-library/src/error-handling.bash
+
+# NOTE: Each test matches to a built-in check outputted via 'kube-linter check'
+
+get_value_from() {
+  value=$(echo "${1}" | jq -r "${2}")
+
+  if [[ -z "${value}" ]] ; then
+    fail "# FATAL-ERROR: get_value_from: value is empty or invalid" || return $?
+  fi
+
+  echo "${value}"
+}
+
+@test "access-to-create-pods" {
+  tmp="tests/checks/access-to-create-pods.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include access-to-create-pods --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "RoleBinding: binding to \"role1\" role that has [create] access to [pods]" ]]
+  [[ "${count}" == "1" ]]
+}
+
+@test "access-to-secrets" {
+  tmp="tests/checks/access-to-secrets.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include access-to-secrets --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "RoleBinding: binding to \"role1\" role that has [get] access to [secrets]" ]]
+  [[ "${count}" == "1" ]]
+}
+
+@test "cluster-admin-role-binding" {
+  tmp="tests/checks/cluster-admin-role-binding.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include cluster-admin-role-binding --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "ClusterRoleBinding: cluster-admin role is bound to [{\"kind\":\"ServiceAccount\",\"name\":\"account1\",\"namespace\":\"namespace-dev\"}]" ]]
+  [[ "${count}" == "1" ]]
+}
+
+@test "dangling-networkpolicy" {
+  tmp="tests/checks/dangling-networkpolicy.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include dangling-networkpolicy --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "NetworkPolicy: no pods found matching networkpolicy's podSelector labels ({map[app.kubernetes.io/name:app1] []}) " ]]
+  [[ "${count}" == "1" ]]
+}
+
+@test "dangling-networkpolicypeer-podselector" {
+  tmp="tests/checks/dangling-networkpolicypeer-podselector.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include dangling-networkpolicypeer-podselector --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "NetworkPolicy: no pods found matching networkpolicy rule's podSelector labels (app.kubernetes.io/name=app2)" ]]
+  [[ "${count}" == "1" ]]
+}
+
+@test "dangling-service" {
+  tmp="tests/checks/dangling-service.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include dangling-service --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Service: no pods found matching service labels (map[app.kubernetes.io/name:app])" ]]
+  [[ "${message2}" == "Service: no pods found matching service labels (map[app.kubernetes.io/name:app])" ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "default-service-account" {
+  tmp="tests/checks/default-service-account.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include default-service-account --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: found matching serviceAccount (\"default\")" ]]
+  [[ "${message2}" == "DeploymentConfig: found matching serviceAccount (\"default\")" ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "deprecated-service-account-field" {
+  tmp="tests/checks/deprecated-service-account-field.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include deprecated-service-account-field --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: serviceAccount is specified (default), but this field is deprecated; use serviceAccountName instead" ]]
+  [[ "${message2}" == "DeploymentConfig: serviceAccount is specified (default), but this field is deprecated; use serviceAccountName instead" ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "docker-sock" {
+  tmp="tests/checks/docker-sock.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include docker-sock --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: host system directory \"/var/run/docker.sock\" is mounted on container \"app\"" ]]
+  [[ "${message2}" == "DeploymentConfig: host system directory \"/var/run/docker.sock\" is mounted on container \"app\"" ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "drop-net-raw-capability" {
+  tmp="tests/checks/drop-net-raw-capability.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include drop-net-raw-capability --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[2].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[2].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: container \"app\" has ADD capability: \"NET_RAW\", which matched with the forbidden capability for containers" ]]
+  [[ "${message2}" == "DeploymentConfig: container \"app\" has ADD capability: \"NET_RAW\", which matched with the forbidden capability for containers" ]]
+  [[ "${count}" == "4" ]]
+}
+
+@test "env-var-secret" {
+  tmp="tests/checks/env-var-secret.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include env-var-secret --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: environment variable SECRET_BLAH in container \"app\" found" ]]
+  [[ "${message2}" == "DeploymentConfig: environment variable SECRET_BLAH in container \"app\" found" ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "exposed-services" {
+  tmp="tests/checks/exposed-services.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include exposed-services --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Service: \"NodePort\" service type is forbidden." ]]
+  [[ "${count}" == "1" ]]
+}
+
+@test "host-ipc" {
+  tmp="tests/checks/host-ipc.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include host-ipc --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: resource shares host's IPC namespace (via hostIPC=true)." ]]
+  [[ "${message2}" == "DeploymentConfig: resource shares host's IPC namespace (via hostIPC=true)." ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "host-network" {
+  tmp="tests/checks/host-network.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include host-network --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: resource shares host's network namespace (via hostNetwork=true)." ]]
+  [[ "${message2}" == "DeploymentConfig: resource shares host's network namespace (via hostNetwork=true)." ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "host-pid" {
+  tmp="tests/checks/host-pid.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include host-pid --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: object shares the host's process namespace (via hostPID=true)." ]]
+  [[ "${message2}" == "DeploymentConfig: object shares the host's process namespace (via hostPID=true)." ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "latest-tag" {
+  tmp="tests/checks/latest-tag.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include latest-tag --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: The container \"app\" is using an invalid container image, \"app:latest\". Please use images that are not blocked by the \`BlockList\` criteria : [\".*:(latest)$\" \"^[^:]*$\" \"(.*/[^:]+)$\"]" ]]
+  [[ "${message2}" == "DeploymentConfig: The container \"app\" is using an invalid container image, \"app:latest\". Please use images that are not blocked by the \`BlockList\` criteria : [\".*:(latest)$\" \"^[^:]*$\" \"(.*/[^:]+)$\"]" ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "minimum-three-replicas" {
+  tmp="tests/checks/minimum-three-replicas.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include minimum-three-replicas --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: object has 2 replicas but minimum required replicas is 3" ]]
+  [[ "${message2}" == "DeploymentConfig: object has 2 replicas but minimum required replicas is 3" ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "mismatching-selector" {
+  tmp="tests/checks/mismatching-selector.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include mismatching-selector --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: labels in pod spec (map[]) do not match labels in selector (&LabelSelector{MatchLabels:map[string]string{app.kubernetes.io/name: app1,},MatchExpressions:[]LabelSelectorRequirement{},})" ]]
+  [[ "${message2}" == "DeploymentConfig: labels in pod spec (map[]) do not match labels in selector (&LabelSelector{MatchLabels:map[string]string{app.kubernetes.io/name: app2,},MatchExpressions:[]LabelSelectorRequirement{},})" ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "no-anti-affinity" {
+  tmp="tests/checks/no-anti-affinity.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include no-anti-affinity --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " +.Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: object has 3 replicas but does not specify inter pod anti-affinity" ]]
+  [[ "${message2}" == "DeploymentConfig: object has 3 replicas but does not specify inter pod anti-affinity" ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "no-extensions-v1beta" {
+  tmp="tests/checks/no-extensions-v1beta.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include no-extensions-v1beta --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "NetworkPolicy: disallowed API object found: extensions/v1beta1, Kind=NetworkPolicy" ]]
+  [[ "${count}" == "1" ]]
+}
+
+@test "no-liveness-probe" {
+  tmp="tests/checks/no-liveness-probe.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include no-liveness-probe --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: container \"app1\" does not specify a liveness probe" ]]
+  [[ "${message2}" == "DeploymentConfig: container \"app2\" does not specify a liveness probe" ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "no-read-only-root-fs" {
+  tmp="tests/checks/no-read-only-root-fs.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include no-read-only-root-fs --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: container \"app\" does not have a read-only root file system" ]]
+  [[ "${message2}" == "DeploymentConfig: container \"app\" does not have a read-only root file system" ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "no-readiness-probe" {
+  tmp="tests/checks/no-readiness-probe.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include no-readiness-probe --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: container \"app\" does not specify a readiness probe" ]]
+  [[ "${message2}" == "DeploymentConfig: container \"app\" does not specify a readiness probe" ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "no-rolling-update-strategy" {
+  tmp="tests/checks/no-rolling-update-strategy.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include no-rolling-update-strategy --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: object has Other strategy type but must match regex ^(RollingUpdate|Rolling)$" ]]
+  [[ "${message2}" == "DeploymentConfig: object has Other strategy type but must match regex ^(RollingUpdate|Rolling)$" ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "non-existent-service-account" {
+  tmp="tests/checks/non-existent-service-account.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include non-existent-service-account --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: serviceAccount \"missing\" not found" ]]
+  [[ "${message2}" == "DeploymentConfig: serviceAccount \"missing\" not found" ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "non-isolated-pod" {
+  tmp="tests/checks/non-isolated-pod.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include non-isolated-pod --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: pods created by this object are non-isolated" ]]
+  [[ "${message2}" == "DeploymentConfig: pods created by this object are non-isolated" ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "privilege-escalation-container" {
+  tmp="tests/checks/privilege-escalation-container.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include privilege-escalation-container --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: container \"app\" has AllowPrivilegeEscalation set to true." ]]
+  [[ "${message2}" == "DeploymentConfig: container \"app\" has AllowPrivilegeEscalation set to true." ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "privileged-container" {
+  tmp="tests/checks/privileged-container.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include privileged-container --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: container \"app\" is privileged" ]]
+  [[ "${message2}" == "DeploymentConfig: container \"app\" is privileged" ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "privileged-ports" {
+  tmp="tests/checks/privileged-ports.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include privileged-ports --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: port 80 is mapped in container \"app\"." ]]
+  [[ "${message2}" == "DeploymentConfig: port 80 is mapped in container \"app\"." ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "read-secret-from-env-var" {
+  tmp="tests/checks/read-secret-from-env-var.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include read-secret-from-env-var --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: environment variable \"TOKEN\" in container \"app\" uses SecretKeyRef" ]]
+  [[ "${message2}" == "DeploymentConfig: environment variable \"TOKEN\" in container \"app\" uses SecretKeyRef" ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "required-annotation-email" {
+  tmp="tests/checks/required-annotation-email.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include required-annotation-email --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: no annotation matching \"email=[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+\" found" ]]
+  [[ "${message2}" == "DeploymentConfig: no annotation matching \"email=[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+\" found" ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "required-label-owner" {
+  tmp="tests/checks/required-label-owner.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include required-label-owner --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: no label matching \"owner=<any>\" found" ]]
+  [[ "${message2}" == "DeploymentConfig: no label matching \"owner=<any>\" found" ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "run-as-non-root" {
+  tmp="tests/checks/run-as-non-root.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include run-as-non-root --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: container \"app\" is not set to runAsNonRoot" ]]
+  [[ "${message2}" == "DeploymentConfig: container \"app2\" is not set to runAsNonRoot" ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "sensitive-host-mounts" {
+  tmp="tests/checks/sensitive-host-mounts.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include sensitive-host-mounts --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: host system directory \"/etc\" is mounted on container \"app\"" ]]
+  [[ "${message2}" == "DeploymentConfig: host system directory \"/etc\" is mounted on container \"app2\"" ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "ssh-port" {
+  tmp="tests/checks/ssh-port.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include ssh-port --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: port 22 and protocol TCP in container \"app\" found" ]]
+  [[ "${message2}" == "DeploymentConfig: port 22 and protocol TCP in container \"app\" found" ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "unsafe-proc-mount" {
+  tmp="tests/checks/unsafe-proc-mount.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include unsafe-proc-mount --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: container \"app\" exposes /proc unsafely (via procMount=Unmasked)." ]]
+  [[ "${message2}" == "DeploymentConfig: container \"app\" exposes /proc unsafely (via procMount=Unmasked)." ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "unsafe-sysctls" {
+  tmp="tests/checks/unsafe-sysctls.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include unsafe-sysctls --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: resource specifies unsafe sysctl \"kernel.sem\"." ]]
+  [[ "${message2}" == "DeploymentConfig: resource specifies unsafe sysctl \"kernel.sem\"." ]]
+  [[ "${count}" == "2" ]]
+}
+
+@test "unset-cpu-requirements" {
+  tmp="tests/checks/unset-cpu-requirements.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include unset-cpu-requirements --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  message3=$(get_value_from "${lines[0]}" '.Reports[2].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[2].Diagnostic.Message')
+  message4=$(get_value_from "${lines[0]}" '.Reports[3].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[3].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: container \"app\" has cpu request 0" ]]
+  [[ "${message2}" == "Deployment: container \"app\" has cpu limit 0" ]]
+  [[ "${message3}" == "DeploymentConfig: container \"app\" has cpu request 0" ]]
+  [[ "${message4}" == "DeploymentConfig: container \"app\" has cpu limit 0" ]]
+  [[ "${count}" == "4" ]]
+}
+
+@test "unset-memory-requirements" {
+  tmp="tests/checks/unset-memory-requirements.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include unset-memory-requirements --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  message3=$(get_value_from "${lines[0]}" '.Reports[2].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[2].Diagnostic.Message')
+  message4=$(get_value_from "${lines[0]}" '.Reports[3].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[3].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: container \"app\" has memory request 0" ]]
+  [[ "${message2}" == "Deployment: container \"app\" has memory limit 0" ]]
+  [[ "${message3}" == "DeploymentConfig: container \"app\" has memory request 0" ]]
+  [[ "${message4}" == "DeploymentConfig: container \"app\" has memory limit 0" ]]
+  [[ "${count}" == "4" ]]
+}
+
+@test "use-namespace" {
+  tmp="tests/checks/use-namespace.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include use-namespace --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: object in default namespace" ]]
+  [[ "${count}" == "1" ]]
+}
+
+@test "wildcard-in-rules" {
+  tmp="tests/checks/wildcard-in-rules.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include wildcard-in-rules --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Role: wildcard "*" in verb specification" ]]
+  [[ "${count}" == "1" ]]
+}
+
+@test "writable-host-mount" {
+  tmp="tests/checks/writable-host-mount.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include writable-host-mount --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
+  message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[1].Diagnostic.Message')
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${message1}" == "Deployment: container app mounts path /config on the host as writable" ]]
+  [[ "${message2}" == "DeploymentConfig: container app2 mounts path /config on the host as writable" ]]
+  [[ "${count}" == "2" ]]
+}
+
+
+
+
+

--- a/e2etests/check-bats-tests.sh
+++ b/e2etests/check-bats-tests.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+run() {
+  local tmp_write_dir=/tmp/kubelinter/$(date +'%d-%m-%Y-%H-%M')
+  mkdir -p "${tmp_write_dir}"
+
+  grep "@test" e2etests/bats-tests.sh | cut -d'"' -f2 > ${tmp_write_dir}/batstests.log
+  ${KUBE_LINTER_BIN:-kube-linter} checks list --format json | jq -r '.[].name' > ${tmp_write_dir}/kubelinterchecks.log
+  diff -c ${tmp_write_dir}/kubelinterchecks.log ${tmp_write_dir}/batstests.log || { echo >&2 "ERROR: The output of '${KUBE_LINTER_BIN} checks list' differs from the tests in 'e2etests/bats-tests.sh'. See above diff."; exit 1; }
+}
+
+run

--- a/tests/checks/access-to-create-pods.yml
+++ b/tests/checks/access-to-create-pods.yml
@@ -1,0 +1,34 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dont-fire
+  namespace: namespace-dev
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: role1
+  namespace: namespace-dev
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: role-binding1
+  namespace: namespace-dev
+subjects:
+  - kind: ServiceAccount
+    name: account1
+    namespace: namespace-dev
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: role1

--- a/tests/checks/access-to-secrets.yml
+++ b/tests/checks/access-to-secrets.yml
@@ -1,0 +1,34 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dont-fire
+  namespace: namespace-dev
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: role1
+  namespace: namespace-dev
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: role-binding1
+  namespace: namespace-dev
+subjects:
+  - kind: ServiceAccount
+    name: account1
+    namespace: namespace-dev
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: role1

--- a/tests/checks/cluster-admin-role-binding.yml
+++ b/tests/checks/cluster-admin-role-binding.yml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dont-fire
+  namespace: namespace-dev
+subjects:
+  - kind: ServiceAccount
+    name: account1
+    namespace: namespace-dev
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: role-binding1
+  namespace: namespace-dev
+subjects:
+  - kind: ServiceAccount
+    name: account1
+    namespace: namespace-dev
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin

--- a/tests/checks/dangling-networkpolicy.yml
+++ b/tests/checks/dangling-networkpolicy.yml
@@ -1,0 +1,8 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: app
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: app1

--- a/tests/checks/dangling-networkpolicypeer-podselector.yml
+++ b/tests/checks/dangling-networkpolicypeer-podselector.yml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: app
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: app1
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: app2
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/tests/checks/dangling-service.yml
+++ b/tests/checks/dangling-service.yml
@@ -1,0 +1,63 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dontfire
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dont-fire
+spec:
+  ports:
+    - name: 8080-tcp
+      port: 8080
+  selector:
+    app.kubernetes.io/name: dontfire
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: app1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app1
+spec:
+  ports:
+    - name: 8080-tcp
+      port: 8080
+  selector:
+    app.kubernetes.io/name: app
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app2
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: app2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app2
+spec:
+  ports:
+    - name: 8080-tcp
+      port: 8080
+  selector:
+    app.kubernetes.io/name: app

--- a/tests/checks/default-service-account.yml
+++ b/tests/checks/default-service-account.yml
@@ -1,0 +1,36 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      serviceAccountName: app
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      serviceAccountName: app
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      serviceAccountName: default
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      serviceAccountName: default

--- a/tests/checks/deprecated-service-account-field.yml
+++ b/tests/checks/deprecated-service-account-field.yml
@@ -1,0 +1,36 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      serviceAccountName: default
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      serviceAccountName: default
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      serviceAccount: default
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      serviceAccount: default

--- a/tests/checks/docker-sock.yml
+++ b/tests/checks/docker-sock.yml
@@ -1,0 +1,68 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          volumeMounts:
+            - name: thingsock
+              mountPath: "/var/run/thing.sock"
+      volumes:
+        - name: thingsock
+          hostPath:
+            path: /var/run/thing.sock
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          volumeMounts:
+            - name: thingsock
+              mountPath: "/var/run/thing.sock"
+      volumes:
+        - name: thingsock
+          hostPath:
+            path: /var/run/thing.sock
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        volumeMounts:
+        - name: dockersock
+          mountPath: "/var/run/docker.sock"
+      volumes:
+      - name: dockersock
+        hostPath:
+          path: /var/run/docker.sock
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        volumeMounts:
+        - name: dockersock
+          mountPath: "/var/run/docker.sock"
+      volumes:
+      - name: dockersock
+        hostPath:
+          path: /var/run/docker.sock

--- a/tests/checks/drop-net-raw-capability.yml
+++ b/tests/checks/drop-net-raw-capability.yml
@@ -1,0 +1,52 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          securityContext:
+            capabilities:
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          securityContext:
+            capabilities:
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        securityContext:
+          capabilities:
+            add:
+              - NET_RAW
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        securityContext:
+          capabilities:
+            add:
+              - NET_RAW

--- a/tests/checks/env-var-secret.yml
+++ b/tests/checks/env-var-secret.yml
@@ -1,0 +1,52 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          env:
+            - name: BLAH
+              value: secretsquirrels
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          env:
+            - name: BLAH
+              value: secretsquirrels
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        env:
+        - name: SECRET_BLAH
+          value: secretsquirrels
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        env:
+        - name: SECRET_BLAH
+          value: secretsquirrels

--- a/tests/checks/exposed-services.yml
+++ b/tests/checks/exposed-services.yml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dont-fire
+spec:
+  selector:
+    app: app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app
+spec:
+  type: NodePort

--- a/tests/checks/host-ipc.yml
+++ b/tests/checks/host-ipc.yml
@@ -1,0 +1,36 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      hostIPC: false
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      hostIPC: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      hostIPC: true
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      hostIPC: true

--- a/tests/checks/host-network.yml
+++ b/tests/checks/host-network.yml
@@ -1,0 +1,36 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      hostNetwork: false
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      hostNetwork: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      hostNetwork: true
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      hostNetwork: true

--- a/tests/checks/host-pid.yml
+++ b/tests/checks/host-pid.yml
@@ -1,0 +1,36 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      hostPID: false
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      hostPID: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      hostPID: true
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      hostPID: true

--- a/tests/checks/latest-tag.yml
+++ b/tests/checks/latest-tag.yml
@@ -1,0 +1,44 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          image: app:v1
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          image: app:v1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        image: app:latest
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        image: app:latest

--- a/tests/checks/minimum-three-replicas.yml
+++ b/tests/checks/minimum-three-replicas.yml
@@ -1,0 +1,28 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  replicas: 3
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: dont-fire
+spec:
+  replicas: 3
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  replicas: 2
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app
+spec:
+  replicas: 2

--- a/tests/checks/mismatching-selector.yml
+++ b/tests/checks/mismatching-selector.yml
@@ -1,0 +1,56 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dont-fire
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dont-fire
+    spec:
+      containers:
+        - name: app
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: dont-fire
+spec:
+  selector:
+    app.kubernetes.io/name: dont-fire
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dont-fire
+    spec:
+      containers:
+        - name: app2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: app1
+  template:
+    spec:
+      containers:
+        - name: app
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app2
+spec:
+  selector:
+    app.kubernetes.io/name: app2
+  template:
+    spec:
+      containers:
+      - name: app2

--- a/tests/checks/no-anti-affinity.yml
+++ b/tests/checks/no-anti-affinity.yml
@@ -1,0 +1,73 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dont-fire
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dont-fire
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                      - dont-fire
+              topologyKey: "kubernetes.io/hostname"
+      containers:
+        - name: app
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: dont-fire
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dont-fire
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                      - dont-fire
+              topologyKey: "kubernetes.io/hostname"
+      containers:
+        - name: app
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: app
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app2
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: app

--- a/tests/checks/no-extensions-v1beta.yml
+++ b/tests/checks/no-extensions-v1beta.yml
@@ -1,0 +1,10 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: app
+---
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  name: app

--- a/tests/checks/no-liveness-probe.yml
+++ b/tests/checks/no-liveness-probe.yml
@@ -1,0 +1,54 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      containers:
+        - name: app1
+          livenessProbe:
+            exec:
+              command:
+                - cat
+                - /tmp/healthy
+            initialDelaySeconds: 5
+            periodSeconds: 5
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      containers:
+        - name: app2
+          livenessProbe:
+            exec:
+              command:
+                - cat
+                - /tmp/healthy
+            initialDelaySeconds: 5
+            periodSeconds: 5
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+spec:
+  template:
+    spec:
+      containers:
+      - name: app1
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app2
+spec:
+  template:
+    spec:
+      containers:
+      - name: app2

--- a/tests/checks/no-read-only-root-fs.yml
+++ b/tests/checks/no-read-only-root-fs.yml
@@ -1,0 +1,52 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: app
+          securityContext:
+            readOnlyRootFilesystem: true
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: dont-fire
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: app
+          securityContext:
+            readOnlyRootFilesystem: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: app
+        securityContext:
+          readOnlyRootFilesystem: false
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app2
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: app
+        securityContext:
+          readOnlyRootFilesystem: false

--- a/tests/checks/no-readiness-probe.yml
+++ b/tests/checks/no-readiness-probe.yml
@@ -1,0 +1,54 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          readinessProbe:
+            exec:
+              command:
+                - cat
+                - /tmp/healthy
+            initialDelaySeconds: 5
+            periodSeconds: 5
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          readinessProbe:
+            exec:
+              command:
+                - cat
+                - /tmp/healthy
+            initialDelaySeconds: 5
+            periodSeconds: 5
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app2
+spec:
+  template:
+    spec:
+      containers:
+      - name: app

--- a/tests/checks/no-rolling-update-strategy.yml
+++ b/tests/checks/no-rolling-update-strategy.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+spec:
+  strategy:
+    type: Other
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app2
+spec:
+  strategy:
+    type: Other

--- a/tests/checks/non-existent-service-account.yml
+++ b/tests/checks/non-existent-service-account.yml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dont-fire
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      serviceAccount: dont-fire
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      serviceAccount: missing
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      serviceAccount: missing

--- a/tests/checks/non-isolated-pod.yml
+++ b/tests/checks/non-isolated-pod.yml
@@ -1,0 +1,82 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dont-fire1
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: dont-fire1
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dont-fire2
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: dont-fire2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  selector:
+    app.kubernetes.io/name: dont-fire1
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dont-fire1
+    spec:
+      containers:
+        - name: app
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: dont-fire
+spec:
+  selector:
+    app.kubernetes.io/name: dont-fire2
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dont-fire2
+    spec:
+      containers:
+        - name: app
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+spec:
+  selector:
+    app.kubernetes.io/name: app1
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: app1
+    spec:
+      containers:
+        - name: app
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app2
+spec:
+  selector:
+    app.kubernetes.io/name: app2
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: app2
+    spec:
+      containers:
+        - name: app

--- a/tests/checks/privilege-escalation-container.yml
+++ b/tests/checks/privilege-escalation-container.yml
@@ -1,0 +1,52 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: app
+          securityContext:
+            allowPrivilegeEscalation: false
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: dont-fire
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: app
+          securityContext:
+            allowPrivilegeEscalation: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: app
+        securityContext:
+          allowPrivilegeEscalation: true
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app2
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: app
+        securityContext:
+          allowPrivilegeEscalation: true

--- a/tests/checks/privileged-container.yml
+++ b/tests/checks/privileged-container.yml
@@ -1,0 +1,52 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: app
+          securityContext:
+            privileged: false
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: dont-fire
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: app
+          securityContext:
+            privileged: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: app
+        securityContext:
+          privileged: true
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app2
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: app
+        securityContext:
+          privileged: true

--- a/tests/checks/privileged-ports.yml
+++ b/tests/checks/privileged-ports.yml
@@ -1,0 +1,52 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: app
+          ports:
+            - containerPort: 8080
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: dont-fire
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: app
+          ports:
+            - containerPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: app
+        ports:
+        - containerPort: 80
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app2
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: app
+        ports:
+        - containerPort: 80

--- a/tests/checks/read-secret-from-env-var.yml
+++ b/tests/checks/read-secret-from-env-var.yml
@@ -1,0 +1,34 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: app
+        env:
+        - name: TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: my-secret
+              key: token
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app2
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: app
+        env:
+        - name: TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: my-secret
+              key: token

--- a/tests/checks/required-annotation-email.yml
+++ b/tests/checks/required-annotation-email.yml
@@ -1,0 +1,28 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+  annotations:
+    email: kubelinter@stackrox.com
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: dont-fire
+  annotations:
+    email: kubelinter@stackrox.com
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+  annotations:
+    whois: kubelinter@stackrox.com
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app2
+  annotations:
+    whois: kubelinter@stackrox.com

--- a/tests/checks/required-label-owner.yml
+++ b/tests/checks/required-label-owner.yml
@@ -1,0 +1,28 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+  labels:
+    owner: kubelinter@stackrox.com
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: dont-fire
+  labels:
+    owner: kubelinter@stackrox.com
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+  labels:
+    dev: kubelinter@stackrox.com
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app2
+  labels:
+    dev: kubelinter@stackrox.com

--- a/tests/checks/run-as-non-root.yml
+++ b/tests/checks/run-as-non-root.yml
@@ -1,0 +1,58 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: app1
+  template:
+    spec:
+      containers:
+        - name: app
+          runAsUser: 1001
+          securityContext:
+            runAsNonRoot: true
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: dont-fire
+spec:
+  selector:
+    app.kubernetes.io/name: app2
+  template:
+    spec:
+      containers:
+        - name: app2
+          runAsUser: 1001
+          securityContext:
+            runAsNonRoot: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: app1
+  template:
+    spec:
+      containers:
+        - name: app
+          runAsUser: 0
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app2
+spec:
+  selector:
+    app.kubernetes.io/name: app2
+  template:
+    spec:
+      containers:
+      - name: app2
+        runAsUser: 0

--- a/tests/checks/sensitive-host-mounts.yml
+++ b/tests/checks/sensitive-host-mounts.yml
@@ -1,0 +1,40 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: app1
+  template:
+    spec:
+      containers:
+      - name: app
+        volumeMounts:
+        - name: config
+          mountPath: /etc
+      volumes:
+      - name: config
+        hostPath:
+          path: /etc
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app2
+spec:
+  selector:
+    app.kubernetes.io/name: app2
+  template:
+    spec:
+      containers:
+      - name: app2
+        runAsUser: 0
+        volumeMounts:
+        - name: config
+          mountPath: /etc
+      volumes:
+      - name: config
+        hostPath:
+          path: /etc

--- a/tests/checks/ssh-port.yml
+++ b/tests/checks/ssh-port.yml
@@ -1,0 +1,56 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: app
+          ports:
+            - containerPort: 2222
+              protocol: TCP
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: dont-fire
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: app
+          ports:
+            - containerPort: 2222
+              protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: app
+        ports:
+        - containerPort: 22
+          protocol: TCP
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app2
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: app
+        ports:
+        - containerPort: 22
+          protocol: TCP

--- a/tests/checks/unsafe-proc-mount.yml
+++ b/tests/checks/unsafe-proc-mount.yml
@@ -1,0 +1,26 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: app
+        securityContext:
+          procMount: Unmasked
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app2
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: app
+        securityContext:
+          procMount: Unmasked

--- a/tests/checks/unsafe-sysctls.yml
+++ b/tests/checks/unsafe-sysctls.yml
@@ -1,0 +1,28 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: app
+      securityContext:
+        sysctls:
+        - name: kernel.sem
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app2
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: app
+      securityContext:
+        sysctls:
+        - name: kernel.sem

--- a/tests/checks/unset-cpu-requirements.yml
+++ b/tests/checks/unset-cpu-requirements.yml
@@ -1,0 +1,30 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: app
+        requests:
+          memory: 1Gi
+        limits:
+          memory: 1Gi
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app2
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: app
+        requests:
+          memory: 1Gi
+        limits:
+          memory: 1Gi

--- a/tests/checks/unset-memory-requirements.yml
+++ b/tests/checks/unset-memory-requirements.yml
@@ -1,0 +1,30 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: app
+        requests:
+          cpu: 1
+        limits:
+          cpu: 1
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app2
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: app
+        requests:
+          cpu: 1
+        limits:
+          cpu: 1

--- a/tests/checks/use-namespace.yml
+++ b/tests/checks/use-namespace.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+  namespace: namespace-dev
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+  namespace: default

--- a/tests/checks/wildcard-in-rules.yml
+++ b/tests/checks/wildcard-in-rules.yml
@@ -1,0 +1,20 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: role1
+  namespace: namespace-dev
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: role1
+  namespace: namespace-dev
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["*"]

--- a/tests/checks/writable-host-mount.yml
+++ b/tests/checks/writable-host-mount.yml
@@ -1,0 +1,40 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: app1
+  template:
+    spec:
+      containers:
+      - name: app
+        volumeMounts:
+        - name: config
+          mountPath: /config
+      volumes:
+      - name: config
+        hostPath:
+          path: /config
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: app2
+spec:
+  selector:
+    app.kubernetes.io/name: app2
+  template:
+    spec:
+      containers:
+      - name: app2
+        runAsUser: 0
+        volumeMounts:
+        - name: config
+          mountPath: /config
+      volumes:
+      - name: config
+        hostPath:
+          path: /config


### PR DESCRIPTION
One thing which I found when playing with kube-linter was I couldn't find many tests which showed the resources which a check would validate against. this PR, adds those examples as tests via `bats`

The basic idea is: for every built-in check, there is a bats test that runs the kube-linter process with only that check enabled. the YAML input has 2 examples (_in most cases_), one that shouldn't trigger the check and one that should.

to run the bats tests, you just do `make bats`. if `diff` is on the machine, it'll also compare the tests to what the built-in checks list outputs to cover off anything missed/removed/new etc. and finally, that is run via a github action.