### PR TITLE
control registering open-shift kinds with a flag

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,8 +31,9 @@ type ChecksConfig struct {
 // Config represents the config file format.
 type Config struct {
 	// +flagName=-
-	CustomChecks []Check      `json:"customChecks,omitempty"`
-	Checks       ChecksConfig `json:"checks,omitempty"`
+	CustomChecks        []Check      `json:"customChecks,omitempty"`
+	Checks              ChecksConfig `json:"checks,omitempty"`
+	AllowOpenshiftKinds bool         `json:"allowOpenshiftKinds"`
 }
 
 // Defines the list of default config filenames to check if parameter isn't passed in

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -27,8 +27,4 @@ func AddFlags(c *cobra.Command, v *viper.Viper) {
 	if err := v.BindPFlag("checks.include", c.Flags().Lookup("include")); err != nil {
 		panic(err)
 	}
-	c.Flags().Bool("", false, "")
-	if err := v.BindPFlag("allowOpenshiftKinds", c.Flags().Lookup("allowOpenshiftKinds")); err != nil {
-		panic(err)
-	}
 }

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -27,4 +27,8 @@ func AddFlags(c *cobra.Command, v *viper.Viper) {
 	if err := v.BindPFlag("checks.include", c.Flags().Lookup("include")); err != nil {
 		panic(err)
 	}
+	c.Flags().Bool("", false, "")
+	if err := v.BindPFlag("allowOpenshiftKinds", c.Flags().Lookup("allowOpenshiftKinds")); err != nil {
+		panic(err)
+	}
 }

--- a/pkg/objectkinds/deployment_like.go
+++ b/pkg/objectkinds/deployment_like.go
@@ -4,26 +4,34 @@ import (
 	"fmt"
 
 	ocsAppsV1 "github.com/openshift/api/apps/v1"
+	"github.com/spf13/viper"
 	appsV1 "k8s.io/api/apps/v1"
 	batchV1 "k8s.io/api/batch/v1"
 	coreV1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+var openshiftKinds = []schema.GroupKind{
+	{Group: ocsAppsV1.GroupName, Kind: "DeploymentConfig"},
+}
+
+var kubeKinds = []schema.GroupKind{
+	{Group: appsV1.GroupName, Kind: "Deployment"},
+	{Group: appsV1.GroupName, Kind: "DaemonSet"},
+	{Group: appsV1.GroupName, Kind: "StatefulSet"},
+	{Group: appsV1.GroupName, Kind: "ReplicaSet"},
+	{Group: coreV1.GroupName, Kind: "Pod"},
+	{Group: coreV1.GroupName, Kind: "ReplicationController"},
+	{Group: batchV1.GroupName, Kind: "Job"},
+	{Group: batchV1.GroupName, Kind: "CronJob"},
+}
 var (
 	deploymentLikeGroupKinds = func() map[schema.GroupKind]struct{} {
 		m := make(map[schema.GroupKind]struct{})
-		for _, gk := range []schema.GroupKind{
-			{Group: appsV1.GroupName, Kind: "Deployment"},
-			{Group: appsV1.GroupName, Kind: "DaemonSet"},
-			{Group: ocsAppsV1.GroupName, Kind: "DeploymentConfig"},
-			{Group: appsV1.GroupName, Kind: "StatefulSet"},
-			{Group: appsV1.GroupName, Kind: "ReplicaSet"},
-			{Group: coreV1.GroupName, Kind: "Pod"},
-			{Group: coreV1.GroupName, Kind: "ReplicationController"},
-			{Group: batchV1.GroupName, Kind: "Job"},
-			{Group: batchV1.GroupName, Kind: "CronJob"},
-		} {
+		if viper.GetBool("allowOpenshiftKinds") {
+			kubeKinds = append(kubeKinds, openshiftKinds...)
+		}
+		for _, gk := range kubeKinds {
 			if _, ok := m[gk]; ok {
 				panic(fmt.Sprintf("group kind double-registered: %v", gk))
 			}


### PR DESCRIPTION
While Running `kube-linter` in an Operator for Dynamic Analyses in a Kubernetes server, Openshift kinds were Not recognised.

Idea is to control registering OpenShift kinds with a flag. 