### PR TITLE
docs: Use YAML for parameters in documentation

### DIFF
--- a/docs/generated/checks.md
+++ b/docs/generated/checks.md
@@ -14,10 +14,18 @@ KubeLinter includes the following built-in checks:
 
 **Parameters**:
 
-```json
-{"resources":["^pods$","^deployments$","^statefulsets$","^replicasets$","^cronjob$","^jobs$","^daemonsets$"],"verbs":["^create$"]}
+```yaml
+resources:
+- ^pods$
+- ^deployments$
+- ^statefulsets$
+- ^replicasets$
+- ^cronjob$
+- ^jobs$
+- ^daemonsets$
+verbs:
+- ^create$
 ```
-
 ## access-to-secrets
 
 **Enabled by default**: No
@@ -30,10 +38,17 @@ KubeLinter includes the following built-in checks:
 
 **Parameters**:
 
-```json
-{"resources":["^secrets$"],"verbs":["^get$","^list$","^delete$","^create$","^watch$","^*$"]}
+```yaml
+resources:
+- ^secrets$
+verbs:
+- ^get$
+- ^list$
+- ^delete$
+- ^create$
+- ^watch$
+- ^*$
 ```
-
 ## cluster-admin-role-binding
 
 **Enabled by default**: No
@@ -43,13 +58,6 @@ KubeLinter includes the following built-in checks:
 **Remediation**: Create and assign a separate role that has access to specific resources/actions needed for the service account.
 
 **Template**: [cluster-admin-role-binding](generated/templates.md#cluster-admin-role-binding)
-
-**Parameters**:
-
-```json
-{}
-```
-
 ## dangling-networkpolicy
 
 **Enabled by default**: No
@@ -59,13 +67,6 @@ KubeLinter includes the following built-in checks:
 **Remediation**: Confirm that your networkPolicy's podselector correctly matches the labels on one of your deployments.
 
 **Template**: [dangling-networkpolicy](generated/templates.md#dangling-networkpolicies)
-
-**Parameters**:
-
-```json
-{}
-```
-
 ## dangling-networkpolicypeer-podselector
 
 **Enabled by default**: No
@@ -75,13 +76,6 @@ KubeLinter includes the following built-in checks:
 **Remediation**: Confirm that your NetworkPolicy's Ingress/Egress peer's podselector correctly matches the labels on one of your deployments.
 
 **Template**: [dangling-networkpolicypeer-podselector](generated/templates.md#dangling-networkpolicypeer-podselector)
-
-**Parameters**:
-
-```json
-{}
-```
-
 ## dangling-service
 
 **Enabled by default**: Yes
@@ -91,13 +85,6 @@ KubeLinter includes the following built-in checks:
 **Remediation**: Confirm that your service's selector correctly matches the labels on one of your deployments.
 
 **Template**: [dangling-service](generated/templates.md#dangling-services)
-
-**Parameters**:
-
-```json
-{}
-```
-
 ## default-service-account
 
 **Enabled by default**: No
@@ -110,10 +97,9 @@ KubeLinter includes the following built-in checks:
 
 **Parameters**:
 
-```json
-{"serviceAccount":"^(|default)$"}
+```yaml
+serviceAccount: ^(|default)$
 ```
-
 ## deprecated-service-account-field
 
 **Enabled by default**: Yes
@@ -123,13 +109,6 @@ KubeLinter includes the following built-in checks:
 **Remediation**: Use the serviceAccountName field instead. If you must specify serviceAccount, ensure values for serviceAccount and serviceAccountName match.
 
 **Template**: [deprecated-service-account-field](generated/templates.md#deprecated-service-account-field)
-
-**Parameters**:
-
-```json
-{}
-```
-
 ## docker-sock
 
 **Enabled by default**: Yes
@@ -142,10 +121,10 @@ KubeLinter includes the following built-in checks:
 
 **Parameters**:
 
-```json
-{"dirs":["docker.sock$"]}
+```yaml
+dirs:
+- docker.sock$
 ```
-
 ## drop-net-raw-capability
 
 **Enabled by default**: Yes
@@ -158,10 +137,10 @@ KubeLinter includes the following built-in checks:
 
 **Parameters**:
 
-```json
-{"forbiddenCapabilities":["NET_RAW"]}
+```yaml
+forbiddenCapabilities:
+- NET_RAW
 ```
-
 ## env-var-secret
 
 **Enabled by default**: Yes
@@ -174,10 +153,10 @@ KubeLinter includes the following built-in checks:
 
 **Parameters**:
 
-```json
-{"name":"(?i).*secret.*","value":".+"}
+```yaml
+name: (?i).*secret.*
+value: .+
 ```
-
 ## exposed-services
 
 **Enabled by default**: No
@@ -190,10 +169,11 @@ KubeLinter includes the following built-in checks:
 
 **Parameters**:
 
-```json
-{"forbiddenServiceTypes":["NodePort","LoadBalancer"]}
+```yaml
+forbiddenServiceTypes:
+- NodePort
+- LoadBalancer
 ```
-
 ## host-ipc
 
 **Enabled by default**: Yes
@@ -203,13 +183,6 @@ KubeLinter includes the following built-in checks:
 **Remediation**: Ensure the host's IPC namespace is not shared.
 
 **Template**: [host-ipc](generated/templates.md#host-ipc)
-
-**Parameters**:
-
-```json
-{}
-```
-
 ## host-network
 
 **Enabled by default**: Yes
@@ -219,13 +192,6 @@ KubeLinter includes the following built-in checks:
 **Remediation**: Ensure the host's network namespace is not shared.
 
 **Template**: [host-network](generated/templates.md#host-network)
-
-**Parameters**:
-
-```json
-{}
-```
-
 ## host-pid
 
 **Enabled by default**: Yes
@@ -235,13 +201,6 @@ KubeLinter includes the following built-in checks:
 **Remediation**: Ensure the host's process namespace is not shared.
 
 **Template**: [host-pid](generated/templates.md#host-pid)
-
-**Parameters**:
-
-```json
-{}
-```
-
 ## latest-tag
 
 **Enabled by default**: Yes
@@ -254,10 +213,12 @@ KubeLinter includes the following built-in checks:
 
 **Parameters**:
 
-```json
-{"BlockList":[".*:(latest)$","^[^:]*$","(.*/[^:]+)$"]}
+```yaml
+BlockList:
+- .*:(latest)$
+- ^[^:]*$
+- (.*/[^:]+)$
 ```
-
 ## minimum-three-replicas
 
 **Enabled by default**: No
@@ -270,10 +231,9 @@ KubeLinter includes the following built-in checks:
 
 **Parameters**:
 
-```json
-{"minReplicas":3}
+```yaml
+minReplicas: 3
 ```
-
 ## mismatching-selector
 
 **Enabled by default**: Yes
@@ -283,13 +243,6 @@ KubeLinter includes the following built-in checks:
 **Remediation**: Confirm that your deployment selector correctly matches the labels in its pod template.
 
 **Template**: [mismatching-selector](generated/templates.md#mismatching-selector)
-
-**Parameters**:
-
-```json
-{}
-```
-
 ## no-anti-affinity
 
 **Enabled by default**: Yes
@@ -302,10 +255,9 @@ KubeLinter includes the following built-in checks:
 
 **Parameters**:
 
-```json
-{"minReplicas":2}
+```yaml
+minReplicas: 2
 ```
-
 ## no-extensions-v1beta
 
 **Enabled by default**: Yes
@@ -318,10 +270,10 @@ KubeLinter includes the following built-in checks:
 
 **Parameters**:
 
-```json
-{"group":"extensions","version":"v1beta.+"}
+```yaml
+group: extensions
+version: v1beta.+
 ```
-
 ## no-liveness-probe
 
 **Enabled by default**: No
@@ -331,13 +283,6 @@ KubeLinter includes the following built-in checks:
 **Remediation**: Specify a liveness probe in your container. Refer to https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ for details.
 
 **Template**: [liveness-probe](generated/templates.md#liveness-probe-not-specified)
-
-**Parameters**:
-
-```json
-{}
-```
-
 ## no-read-only-root-fs
 
 **Enabled by default**: Yes
@@ -347,13 +292,6 @@ KubeLinter includes the following built-in checks:
 **Remediation**: Set readOnlyRootFilesystem to true in the container securityContext.
 
 **Template**: [read-only-root-fs](generated/templates.md#read-only-root-filesystems)
-
-**Parameters**:
-
-```json
-{}
-```
-
 ## no-readiness-probe
 
 **Enabled by default**: No
@@ -363,13 +301,6 @@ KubeLinter includes the following built-in checks:
 **Remediation**: Specify a readiness probe in your container. Refer to https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ for details.
 
 **Template**: [readiness-probe](generated/templates.md#readiness-probe-not-specified)
-
-**Parameters**:
-
-```json
-{}
-```
-
 ## no-rolling-update-strategy
 
 **Enabled by default**: No
@@ -382,10 +313,9 @@ KubeLinter includes the following built-in checks:
 
 **Parameters**:
 
-```json
-{"strategyTypeRegex":"^(RollingUpdate|Rolling)$"}
+```yaml
+strategyTypeRegex: ^(RollingUpdate|Rolling)$
 ```
-
 ## non-existent-service-account
 
 **Enabled by default**: Yes
@@ -395,13 +325,6 @@ KubeLinter includes the following built-in checks:
 **Remediation**: Create the missing service account, or refer to an existing service account.
 
 **Template**: [non-existent-service-account](generated/templates.md#non-existent-service-account)
-
-**Parameters**:
-
-```json
-{}
-```
-
 ## non-isolated-pod
 
 **Enabled by default**: No
@@ -411,13 +334,6 @@ KubeLinter includes the following built-in checks:
 **Remediation**: Ensure pod does not accept unsafe traffic by isolating it with a NetworkPolicy. See https://cloud.redhat.com/blog/guide-to-kubernetes-ingress-network-policies for more details.
 
 **Template**: [non-isolated-pod](generated/templates.md#non-isolated-pods)
-
-**Parameters**:
-
-```json
-{}
-```
-
 ## privilege-escalation-container
 
 **Enabled by default**: Yes
@@ -427,13 +343,6 @@ KubeLinter includes the following built-in checks:
 **Remediation**: Ensure containers do not allow privilege escalation by setting allowPrivilegeEscalation=false." See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ for more details.
 
 **Template**: [privilege-escalation-container](generated/templates.md#privilege-escalation-on-containers)
-
-**Parameters**:
-
-```json
-{}
-```
-
 ## privileged-container
 
 **Enabled by default**: Yes
@@ -443,13 +352,6 @@ KubeLinter includes the following built-in checks:
 **Remediation**: Do not run your container as privileged unless it is required.
 
 **Template**: [privileged](generated/templates.md#privileged-containers)
-
-**Parameters**:
-
-```json
-{}
-```
-
 ## privileged-ports
 
 **Enabled by default**: No
@@ -459,13 +361,6 @@ KubeLinter includes the following built-in checks:
 **Remediation**: Ensure privileged ports [0, 1024] are not mapped within containers.
 
 **Template**: [privileged-ports](generated/templates.md#privileged-ports)
-
-**Parameters**:
-
-```json
-{}
-```
-
 ## read-secret-from-env-var
 
 **Enabled by default**: No
@@ -475,13 +370,6 @@ KubeLinter includes the following built-in checks:
 **Remediation**: If possible, rewrite application code to read secrets from mounted secret files, rather than from environment variables. Refer to https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets for details.
 
 **Template**: [read-secret-from-env-var](generated/templates.md#read-secret-from-environment-variables)
-
-**Parameters**:
-
-```json
-{}
-```
-
 ## required-annotation-email
 
 **Enabled by default**: No
@@ -494,10 +382,10 @@ KubeLinter includes the following built-in checks:
 
 **Parameters**:
 
-```json
-{"key":"email","value":"[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+"}
+```yaml
+key: email
+value: '[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+'
 ```
-
 ## required-label-owner
 
 **Enabled by default**: No
@@ -510,10 +398,9 @@ KubeLinter includes the following built-in checks:
 
 **Parameters**:
 
-```json
-{"key":"owner"}
+```yaml
+key: owner
 ```
-
 ## run-as-non-root
 
 **Enabled by default**: Yes
@@ -523,13 +410,6 @@ KubeLinter includes the following built-in checks:
 **Remediation**: Set runAsUser to a non-zero number and runAsNonRoot to true in your pod or container securityContext. Refer to https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ for details.
 
 **Template**: [run-as-non-root](generated/templates.md#run-as-non-root-user)
-
-**Parameters**:
-
-```json
-{}
-```
-
 ## sensitive-host-mounts
 
 **Enabled by default**: Yes
@@ -542,10 +422,17 @@ KubeLinter includes the following built-in checks:
 
 **Parameters**:
 
-```json
-{"dirs":["^/$","^/boot$","^/dev$","^/etc$","^/lib$","^/proc$","^/sys$","^/usr$"]}
+```yaml
+dirs:
+- ^/$
+- ^/boot$
+- ^/dev$
+- ^/etc$
+- ^/lib$
+- ^/proc$
+- ^/sys$
+- ^/usr$
 ```
-
 ## ssh-port
 
 **Enabled by default**: Yes
@@ -558,10 +445,10 @@ KubeLinter includes the following built-in checks:
 
 **Parameters**:
 
-```json
-{"port":22,"protocol":"TCP"}
+```yaml
+port: 22
+protocol: TCP
 ```
-
 ## unsafe-proc-mount
 
 **Enabled by default**: No
@@ -571,13 +458,6 @@ KubeLinter includes the following built-in checks:
 **Remediation**: Ensure container does not unsafely exposes parts of /proc by setting procMount=Default.  Unmasked ProcMount bypasses the default masking behavior of the container runtime. See https://kubernetes.io/docs/concepts/security/pod-security-standards/ for more details.
 
 **Template**: [unsafe-proc-mount](generated/templates.md#unsafe-proc-mount)
-
-**Parameters**:
-
-```json
-{}
-```
-
 ## unsafe-sysctls
 
 **Enabled by default**: Yes
@@ -590,10 +470,14 @@ KubeLinter includes the following built-in checks:
 
 **Parameters**:
 
-```json
-{"unsafeSysCtls":["kernel.msg","kernel.sem","kernel.shm","fs.mqueue.","net."]}
+```yaml
+unsafeSysCtls:
+- kernel.msg
+- kernel.sem
+- kernel.shm
+- fs.mqueue.
+- net.
 ```
-
 ## unset-cpu-requirements
 
 **Enabled by default**: Yes
@@ -606,10 +490,11 @@ KubeLinter includes the following built-in checks:
 
 **Parameters**:
 
-```json
-{"lowerBoundMillis":0,"requirementsType":"any","upperBoundMillis":0}
+```yaml
+lowerBoundMillis: 0
+requirementsType: any
+upperBoundMillis: 0
 ```
-
 ## unset-memory-requirements
 
 **Enabled by default**: Yes
@@ -622,10 +507,11 @@ KubeLinter includes the following built-in checks:
 
 **Parameters**:
 
-```json
-{"lowerBoundMB":0,"requirementsType":"any","upperBoundMB":0}
+```yaml
+lowerBoundMB: 0
+requirementsType: any
+upperBoundMB: 0
 ```
-
 ## use-namespace
 
 **Enabled by default**: No
@@ -635,13 +521,6 @@ KubeLinter includes the following built-in checks:
 **Remediation**: Create namespaces for objects in your deployment.
 
 **Template**: [use-namespace](generated/templates.md#use-namespaces-for-administrative-boundaries-between-resources)
-
-**Parameters**:
-
-```json
-{}
-```
-
 ## wildcard-in-rules
 
 **Enabled by default**: No
@@ -651,13 +530,6 @@ KubeLinter includes the following built-in checks:
 **Remediation**: Where possible replace any use of wildcards in clusterroles and roles with specific objects or actions.
 
 **Template**: [wildcard-in-rules](generated/templates.md#wildcard-use-in-role-and-clusterrole-rules)
-
-**Parameters**:
-
-```json
-{}
-```
-
 ## writable-host-mount
 
 **Enabled by default**: No
@@ -667,10 +539,3 @@ KubeLinter includes the following built-in checks:
 **Remediation**: Set containers to mount host paths as readOnly, if you need to access files on the host.
 
 **Template**: [writable-host-mount](generated/templates.md#writable-host-mounts)
-
-**Parameters**:
-
-```json
-{}
-```
-

--- a/docs/generated/templates.md
+++ b/docs/generated/templates.md
@@ -10,35 +10,31 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: Role,ClusterRole,ClusterRoleBinding,RoleBinding
 
+
 **Parameters**:
 
-```json
-[
-  {
-    "name": "flagRolesNotFound",
-    "type": "boolean",
-    "description": "Set to true to flag the roles that are referenced in bindings but not found in the context",
-    "required": false
-  },
-  {
-    "name": "resources",
-    "type": "array",
-    "description": "An array of regular expressions specifying resources. e.g. ^secrets$ for secrets and ^*$ for any resources",
-    "required": false,
-    "regexAllowed": true,
-    "negationAllowed": false,
-    "arrayElemType": "string"
-  },
-  {
-    "name": "verbs",
-    "type": "array",
-    "description": "An array of regular expressions specifying verbs. e.g. ^create$ for create and ^*$ for any k8s verbs",
-    "required": false,
-    "regexAllowed": true,
-    "negationAllowed": false,
-    "arrayElemType": "string"
-  }
-]
+```yaml
+- description: Set to true to flag the roles that are referenced in bindings but not
+    found in the context
+  name: flagRolesNotFound
+  required: false
+  type: boolean
+- arrayElemType: string
+  description: An array of regular expressions specifying resources. e.g. ^secrets$
+    for secrets and ^*$ for any resources
+  name: resources
+  negationAllowed: false
+  regexAllowed: true
+  required: false
+  type: array
+- arrayElemType: string
+  description: An array of regular expressions specifying verbs. e.g. ^create$ for
+    create and ^*$ for any k8s verbs
+  name: verbs
+  negationAllowed: false
+  regexAllowed: true
+  required: false
+  type: array
 ```
 
 ## Anti affinity not specified
@@ -49,25 +45,22 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
+
 **Parameters**:
 
-```json
-[
-  {
-    "name": "minReplicas",
-    "type": "integer",
-    "description": "The minimum number of replicas a deployment must have before anti-affinity is enforced on it",
-    "required": false
-  },
-  {
-    "name": "topologyKey",
-    "type": "string",
-    "description": "The topology key that the anti-affinity term should use. If not specified, it defaults to \"kubernetes.io/hostname\".",
-    "required": false,
-    "regexAllowed": true,
-    "negationAllowed": true
-  }
-]
+```yaml
+- description: The minimum number of replicas a deployment must have before anti-affinity
+    is enforced on it
+  name: minReplicas
+  required: false
+  type: integer
+- description: The topology key that the anti-affinity term should use. If not specified,
+    it defaults to "kubernetes.io/hostname".
+  name: topologyKey
+  negationAllowed: true
+  regexAllowed: true
+  required: false
+  type: string
 ```
 
 ## cluster-admin Role Binding
@@ -78,11 +71,6 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: ClusterRoleBinding
 
-**Parameters**:
-
-```json
-[]
-```
 
 ## CPU Requirements
 
@@ -92,31 +80,26 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
+
 **Parameters**:
 
-```json
-[
-  {
-    "name": "requirementsType",
-    "type": "string",
-    "description": "The type of requirement. Use any to apply to both requests and limits.",
-    "required": true,
-    "regexAllowed": true,
-    "negationAllowed": true
-  },
-  {
-    "name": "lowerBoundMillis",
-    "type": "integer",
-    "description": "The lower bound of the requirement (inclusive), specified as a number of milli-cores. If not specified, it is treated as a lower bound of zero.",
-    "required": false
-  },
-  {
-    "name": "upperBoundMillis",
-    "type": "integer",
-    "description": "The upper bound of the requirement (inclusive), specified as a number of milli-cores. If not specified, it is treated as \"no upper bound\".",
-    "required": false
-  }
-]
+```yaml
+- description: The type of requirement. Use any to apply to both requests and limits.
+  name: requirementsType
+  negationAllowed: true
+  regexAllowed: true
+  required: true
+  type: string
+- description: The lower bound of the requirement (inclusive), specified as a number
+    of milli-cores. If not specified, it is treated as a lower bound of zero.
+  name: lowerBoundMillis
+  required: false
+  type: integer
+- description: The upper bound of the requirement (inclusive), specified as a number
+    of milli-cores. If not specified, it is treated as "no upper bound".
+  name: upperBoundMillis
+  required: false
+  type: integer
 ```
 
 ## Dangling NetworkPolicies
@@ -127,11 +110,6 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
-**Parameters**:
-
-```json
-[]
-```
 
 ## Dangling NetworkPolicyPeer PodSelector
 
@@ -141,11 +119,6 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
-**Parameters**:
-
-```json
-[]
-```
 
 ## Dangling Services
 
@@ -155,11 +128,6 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
-**Parameters**:
-
-```json
-[]
-```
 
 ## Deprecated Service Account Field
 
@@ -169,11 +137,6 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
-**Parameters**:
-
-```json
-[]
-```
 
 ## Disallowed API Objects
 
@@ -183,46 +146,36 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: Any
 
+
 **Parameters**:
 
-```json
-[
-  {
-    "name": "group",
-    "type": "string",
-    "description": "The disallowed object group.",
-    "required": false,
-    "examples": [
-      "apps"
-    ],
-    "regexAllowed": true,
-    "negationAllowed": true
-  },
-  {
-    "name": "version",
-    "type": "string",
-    "description": "The disallowed object API version.",
-    "required": false,
-    "examples": [
-      "v1",
-      "v1beta1"
-    ],
-    "regexAllowed": true,
-    "negationAllowed": true
-  },
-  {
-    "name": "kind",
-    "type": "string",
-    "description": "The disallowed kind.",
-    "required": false,
-    "examples": [
-      "Deployment",
-      "DaemonSet"
-    ],
-    "regexAllowed": true,
-    "negationAllowed": true
-  }
-]
+```yaml
+- description: The disallowed object group.
+  examples:
+  - apps
+  name: group
+  negationAllowed: true
+  regexAllowed: true
+  required: false
+  type: string
+- description: The disallowed object API version.
+  examples:
+  - v1
+  - v1beta1
+  name: version
+  negationAllowed: true
+  regexAllowed: true
+  required: false
+  type: string
+- description: The disallowed kind.
+  examples:
+  - Deployment
+  - DaemonSet
+  name: kind
+  negationAllowed: true
+  regexAllowed: true
+  required: false
+  type: string
 ```
 
 ## Environment Variables
@@ -233,27 +186,22 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
+
 **Parameters**:
 
-```json
-[
-  {
-    "name": "name",
-    "type": "string",
-    "description": "The name of the environment variable.",
-    "required": true,
-    "regexAllowed": true,
-    "negationAllowed": true
-  },
-  {
-    "name": "value",
-    "type": "string",
-    "description": "The value of the environment variable.",
-    "required": false,
-    "regexAllowed": true,
-    "negationAllowed": true
-  }
-]
+```yaml
+- description: The name of the environment variable.
+  name: name
+  negationAllowed: true
+  regexAllowed: true
+  required: true
+  type: string
+- description: The value of the environment variable.
+  name: value
+  negationAllowed: true
+  regexAllowed: true
+  required: false
+  type: string
 ```
 
 ## Forbidden Annotation
@@ -264,27 +212,22 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: Any
 
+
 **Parameters**:
 
-```json
-[
-  {
-    "name": "key",
-    "type": "string",
-    "description": "Key of the forbidden annotation.",
-    "required": true,
-    "regexAllowed": true,
-    "negationAllowed": true
-  },
-  {
-    "name": "value",
-    "type": "string",
-    "description": "Value of the forbidden annotation.",
-    "required": false,
-    "regexAllowed": true,
-    "negationAllowed": true
-  }
-]
+```yaml
+- description: Key of the forbidden annotation.
+  name: key
+  negationAllowed: true
+  regexAllowed: true
+  required: true
+  type: string
+- description: Value of the forbidden annotation.
+  name: value
+  negationAllowed: true
+  regexAllowed: true
+  required: false
+  type: string
 ```
 
 ## Forbidden Service Types
@@ -295,20 +238,17 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: Service
 
+
 **Parameters**:
 
-```json
-[
-  {
-    "name": "forbiddenServiceTypes",
-    "type": "array",
-    "description": "An array of service types that should not be used",
-    "required": false,
-    "regexAllowed": false,
-    "negationAllowed": false,
-    "arrayElemType": "string"
-  }
-]
+```yaml
+- arrayElemType: string
+  description: An array of service types that should not be used
+  name: forbiddenServiceTypes
+  negationAllowed: false
+  regexAllowed: false
+  required: false
+  type: array
 ```
 
 ## Host IPC
@@ -319,11 +259,6 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
-**Parameters**:
-
-```json
-[]
-```
 
 ## Host Mounts
 
@@ -333,20 +268,18 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
+
 **Parameters**:
 
-```json
-[
-  {
-    "name": "dirs",
-    "type": "array",
-    "description": "An array of regular expressions specifying system directories to be mounted on containers. e.g. ^/usr$ for /usr",
-    "required": false,
-    "regexAllowed": true,
-    "negationAllowed": false,
-    "arrayElemType": "string"
-  }
-]
+```yaml
+- arrayElemType: string
+  description: An array of regular expressions specifying system directories to be
+    mounted on containers. e.g. ^/usr$ for /usr
+  name: dirs
+  negationAllowed: false
+  regexAllowed: true
+  required: false
+  type: array
 ```
 
 ## Host Network
@@ -357,11 +290,6 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
-**Parameters**:
-
-```json
-[]
-```
 
 ## Host PID
 
@@ -371,11 +299,6 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
-**Parameters**:
-
-```json
-[]
-```
 
 ## Image Pull Policy
 
@@ -385,20 +308,17 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
+
 **Parameters**:
 
-```json
-[
-  {
-    "name": "forbiddenPolicies",
-    "type": "array",
-    "description": "list of forbidden image pull policy",
-    "required": false,
-    "regexAllowed": false,
-    "negationAllowed": false,
-    "arrayElemType": "string"
-  }
-]
+```yaml
+- arrayElemType: string
+  description: list of forbidden image pull policy
+  name: forbiddenPolicies
+  negationAllowed: false
+  regexAllowed: false
+  required: false
+  type: array
 ```
 
 ## Latest Tag
@@ -409,29 +329,26 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
+
 **Parameters**:
 
-```json
-[
-  {
-    "name": "blockList",
-    "type": "array",
-    "description": "list of regular expressions specifying pattern(s) for container images that will be blocked. */",
-    "required": false,
-    "regexAllowed": true,
-    "negationAllowed": true,
-    "arrayElemType": "string"
-  },
-  {
-    "name": "allowList",
-    "type": "array",
-    "description": "list of regular expressions specifying pattern(s) for container images that will be allowed.",
-    "required": false,
-    "regexAllowed": true,
-    "negationAllowed": true,
-    "arrayElemType": "string"
-  }
-]
+```yaml
+- arrayElemType: string
+  description: list of regular expressions specifying pattern(s) for container images
+    that will be blocked. */
+  name: blockList
+  negationAllowed: true
+  regexAllowed: true
+  required: false
+  type: array
+- arrayElemType: string
+  description: list of regular expressions specifying pattern(s) for container images
+    that will be allowed.
+  name: allowList
+  negationAllowed: true
+  regexAllowed: true
+  required: false
+  type: array
 ```
 
 ## Liveness Probe Not Specified
@@ -442,11 +359,6 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
-**Parameters**:
-
-```json
-[]
-```
 
 ## Memory Requirements
 
@@ -456,31 +368,26 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
+
 **Parameters**:
 
-```json
-[
-  {
-    "name": "requirementsType",
-    "type": "string",
-    "description": "The type of requirement. Use any to apply to both requests and limits.",
-    "required": true,
-    "regexAllowed": true,
-    "negationAllowed": true
-  },
-  {
-    "name": "lowerBoundMB",
-    "type": "integer",
-    "description": "The lower bound of the requirement (inclusive), specified as a number of MB.",
-    "required": false
-  },
-  {
-    "name": "upperBoundMB",
-    "type": "integer",
-    "description": "The upper bound of the requirement (inclusive), specified as a number of MB. If not specified, it is treated as \"no upper bound\".",
-    "required": false
-  }
-]
+```yaml
+- description: The type of requirement. Use any to apply to both requests and limits.
+  name: requirementsType
+  negationAllowed: true
+  regexAllowed: true
+  required: true
+  type: string
+- description: The lower bound of the requirement (inclusive), specified as a number
+    of MB.
+  name: lowerBoundMB
+  required: false
+  type: integer
+- description: The upper bound of the requirement (inclusive), specified as a number
+    of MB. If not specified, it is treated as "no upper bound".
+  name: upperBoundMB
+  required: false
+  type: integer
 ```
 
 ## Minimum replicas
@@ -491,17 +398,14 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
+
 **Parameters**:
 
-```json
-[
-  {
-    "name": "minReplicas",
-    "type": "integer",
-    "description": "The minimum number of replicas a deployment should have",
-    "required": false
-  }
-]
+```yaml
+- description: The minimum number of replicas a deployment should have
+  name: minReplicas
+  required: false
+  type: integer
 ```
 
 ## Mismatching Selector
@@ -512,11 +416,6 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
-**Parameters**:
-
-```json
-[]
-```
 
 ## Non-Existent Service Account
 
@@ -526,11 +425,6 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
-**Parameters**:
-
-```json
-[]
-```
 
 ## Non Isolated Pods
 
@@ -540,11 +434,6 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: NetworkPolicy
 
-**Parameters**:
-
-```json
-[]
-```
 
 ## Ports
 
@@ -554,25 +443,20 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
+
 **Parameters**:
 
-```json
-[
-  {
-    "name": "port",
-    "type": "integer",
-    "description": "The port",
-    "required": false
-  },
-  {
-    "name": "protocol",
-    "type": "string",
-    "description": "The protocol",
-    "required": false,
-    "regexAllowed": true,
-    "negationAllowed": true
-  }
-]
+```yaml
+- description: The port
+  name: port
+  required: false
+  type: integer
+- description: The protocol
+  name: protocol
+  negationAllowed: true
+  regexAllowed: true
+  required: false
+  type: string
 ```
 
 ## Privilege Escalation on Containers
@@ -583,11 +467,6 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
-**Parameters**:
-
-```json
-[]
-```
 
 ## Privileged Containers
 
@@ -597,11 +476,6 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
-**Parameters**:
-
-```json
-[]
-```
 
 ## Privileged Ports
 
@@ -611,11 +485,6 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
-**Parameters**:
-
-```json
-[]
-```
 
 ## Read-only Root Filesystems
 
@@ -625,11 +494,6 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
-**Parameters**:
-
-```json
-[]
-```
 
 ## Read Secret From Environment Variables
 
@@ -639,11 +503,6 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
-**Parameters**:
-
-```json
-[]
-```
 
 ## Readiness Probe Not Specified
 
@@ -653,11 +512,6 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
-**Parameters**:
-
-```json
-[]
-```
 
 ## Required Annotation
 
@@ -667,27 +521,22 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: Any
 
+
 **Parameters**:
 
-```json
-[
-  {
-    "name": "key",
-    "type": "string",
-    "description": "Key of the required label.",
-    "required": true,
-    "regexAllowed": true,
-    "negationAllowed": true
-  },
-  {
-    "name": "value",
-    "type": "string",
-    "description": "Value of the required label.",
-    "required": false,
-    "regexAllowed": true,
-    "negationAllowed": true
-  }
-]
+```yaml
+- description: Key of the required label.
+  name: key
+  negationAllowed: true
+  regexAllowed: true
+  required: true
+  type: string
+- description: Value of the required label.
+  name: value
+  negationAllowed: true
+  regexAllowed: true
+  required: false
+  type: string
 ```
 
 ## Required Label
@@ -698,27 +547,22 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: Any
 
+
 **Parameters**:
 
-```json
-[
-  {
-    "name": "key",
-    "type": "string",
-    "description": "Key of the required label.",
-    "required": true,
-    "regexAllowed": true,
-    "negationAllowed": true
-  },
-  {
-    "name": "value",
-    "type": "string",
-    "description": "Value of the required label.",
-    "required": false,
-    "regexAllowed": true,
-    "negationAllowed": true
-  }
-]
+```yaml
+- description: Key of the required label.
+  name: key
+  negationAllowed: true
+  regexAllowed: true
+  required: true
+  type: string
+- description: Value of the required label.
+  name: value
+  negationAllowed: true
+  regexAllowed: true
+  required: false
+  type: string
 ```
 
 ## Run as non-root user
@@ -729,11 +573,6 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
-**Parameters**:
-
-```json
-[]
-```
 
 ## Service Account
 
@@ -743,19 +582,16 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
+
 **Parameters**:
 
-```json
-[
-  {
-    "name": "serviceAccount",
-    "type": "string",
-    "description": "A regex specifying the required service account to match.",
-    "required": true,
-    "regexAllowed": true,
-    "negationAllowed": true
-  }
-]
+```yaml
+- description: A regex specifying the required service account to match.
+  name: serviceAccount
+  negationAllowed: true
+  regexAllowed: true
+  required: true
+  type: string
 ```
 
 ## Unsafe Proc Mount
@@ -766,11 +602,6 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
-**Parameters**:
-
-```json
-[]
-```
 
 ## Unsafe Sysctls
 
@@ -780,20 +611,17 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
+
 **Parameters**:
 
-```json
-[
-  {
-    "name": "unsafeSysCtls",
-    "type": "array",
-    "description": "An array of unsafe system controls",
-    "required": false,
-    "regexAllowed": false,
-    "negationAllowed": false,
-    "arrayElemType": "string"
-  }
-]
+```yaml
+- arrayElemType: string
+  description: An array of unsafe system controls
+  name: unsafeSysCtls
+  negationAllowed: false
+  regexAllowed: false
+  required: false
+  type: array
 ```
 
 ## Update configuration
@@ -804,51 +632,44 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
+
 **Parameters**:
 
-```json
-[
-  {
-    "name": "strategyTypeRegex",
-    "type": "string",
-    "description": "A regular expression the defines the type of update strategy allowed.",
-    "required": true,
-    "regexAllowed": true,
-    "negationAllowed": true
-  },
-  {
-    "name": "maxPodsUnavailable",
-    "type": "string",
-    "description": "The maximum value that be set in a RollingUpdate configuration for the MaxUnavailable.  This can be an integer or a percent.",
-    "required": false,
-    "regexAllowed": true,
-    "negationAllowed": true
-  },
-  {
-    "name": "minPodsUnavailable",
-    "type": "string",
-    "description": "The minimum value that be set in a RollingUpdate configuration for the MaxUnavailable.  This can be an integer or a percent.",
-    "required": false,
-    "regexAllowed": true,
-    "negationAllowed": true
-  },
-  {
-    "name": "maxSurge",
-    "type": "string",
-    "description": "The maximum value that be set in a RollingUpdate configuration for the MaxSurge.  This can be an integer or a percent.",
-    "required": false,
-    "regexAllowed": true,
-    "negationAllowed": true
-  },
-  {
-    "name": "minSurge",
-    "type": "string",
-    "description": "The minimum value that be set in a RollingUpdate configuration for the MaxSurge.  This can be an integer or a percent.",
-    "required": false,
-    "regexAllowed": true,
-    "negationAllowed": true
-  }
-]
+```yaml
+- description: A regular expression the defines the type of update strategy allowed.
+  name: strategyTypeRegex
+  negationAllowed: true
+  regexAllowed: true
+  required: true
+  type: string
+- description: The maximum value that be set in a RollingUpdate configuration for
+    the MaxUnavailable.  This can be an integer or a percent.
+  name: maxPodsUnavailable
+  negationAllowed: true
+  regexAllowed: true
+  required: false
+  type: string
+- description: The minimum value that be set in a RollingUpdate configuration for
+    the MaxUnavailable.  This can be an integer or a percent.
+  name: minPodsUnavailable
+  negationAllowed: true
+  regexAllowed: true
+  required: false
+  type: string
+- description: The maximum value that be set in a RollingUpdate configuration for
+    the MaxSurge.  This can be an integer or a percent.
+  name: maxSurge
+  negationAllowed: true
+  regexAllowed: true
+  required: false
+  type: string
+- description: The minimum value that be set in a RollingUpdate configuration for
+    the MaxSurge.  This can be an integer or a percent.
+  name: minSurge
+  negationAllowed: true
+  regexAllowed: true
+  required: false
+  type: string
 ```
 
 ## Use Namespaces for Administrative Boundaries between Resources
@@ -859,11 +680,6 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike,Service
 
-**Parameters**:
-
-```json
-[]
-```
 
 ## Verify container capabilities
 
@@ -873,29 +689,26 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
+
 **Parameters**:
 
-```json
-[
-  {
-    "name": "forbiddenCapabilities",
-    "type": "array",
-    "description": "List of capabilities that needs to be removed from containers.",
-    "required": false,
-    "regexAllowed": false,
-    "negationAllowed": false,
-    "arrayElemType": "string"
-  },
-  {
-    "name": "exceptions",
-    "type": "array",
-    "description": "List of capabilities that are exceptions to the above list. This should only be filled when the above contains \"all\", and is used to forgive capabilities in ADD list.",
-    "required": false,
-    "regexAllowed": false,
-    "negationAllowed": false,
-    "arrayElemType": "string"
-  }
-]
+```yaml
+- arrayElemType: string
+  description: List of capabilities that needs to be removed from containers.
+  name: forbiddenCapabilities
+  negationAllowed: false
+  regexAllowed: false
+  required: false
+  type: array
+- arrayElemType: string
+  description: List of capabilities that are exceptions to the above list. This should
+    only be filled when the above contains "all", and is used to forgive capabilities
+    in ADD list.
+  name: exceptions
+  negationAllowed: false
+  regexAllowed: false
+  required: false
+  type: array
 ```
 
 ## Wildcard Use in Role and ClusterRole Rules
@@ -906,11 +719,6 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: Role,ClusterRole
 
-**Parameters**:
-
-```json
-[]
-```
 
 ## Writable Host Mounts
 
@@ -920,9 +728,4 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: DeploymentLike
 
-**Parameters**:
-
-```json
-[]
-```
 

--- a/pkg/command/checks/command.go
+++ b/pkg/command/checks/command.go
@@ -45,11 +45,11 @@ KubeLinter includes the following built-in checks:
 **Remediation**: {{.Remediation}}
 
 **Template**: [{{.Template}}](generated/templates.md#{{ templateLink . }})
-
+{{ if .Params }}
 **Parameters**:
 
-{{ mustToJson (default (dict) .Params ) | codeBlock "json" }}
-
+{{ mustToYaml (default (dict) .Params ) | codeBlock "yaml" }}
+{{ end -}}
 {{ end -}}
 `
 )

--- a/pkg/command/common/template.go
+++ b/pkg/command/common/template.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"github.com/ghodss/yaml"
 	"strings"
 	"text/template"
 
@@ -27,6 +28,13 @@ var (
 				finalNewline = ""
 			}
 			return "```" + lang + "\n" + code + finalNewline + "```"
+		},
+		"mustToYaml": func(v interface{}) (string, error) {
+			output, err := yaml.Marshal(v)
+			if err != nil {
+				return "", err
+			}
+			return string(output), nil
 		},
 	}
 

--- a/pkg/command/common/template.go
+++ b/pkg/command/common/template.go
@@ -1,9 +1,10 @@
 package common
 
 import (
-	"github.com/ghodss/yaml"
 	"strings"
 	"text/template"
+
+	"github.com/ghodss/yaml"
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/fatih/color"

--- a/pkg/command/templates/command.go
+++ b/pkg/command/templates/command.go
@@ -23,10 +23,11 @@ KubeLinter supports the following templates:
 
 **Supported Objects**: {{ join "," .SupportedObjectKinds.ObjectKinds }}
 
+{{ if .HumanReadableParameters }}
 **Parameters**:
 
-{{ toPrettyJson .HumanReadableParameters | codeBlock "json" }}
-
+{{ mustToYaml .HumanReadableParameters | codeBlock "yaml" }}
+{{ end }}
 {{ end -}}
 `
 


### PR DESCRIPTION
Currently we display checks and template params as JSON without highlighting (see #192). What's more for checks we use plain JSON and for templates pretty printed. This is weird as in our own codebase and examples we use YAML. 

This PR:
- changes JSON to YAML in generated documentation 
- changes JSON to YAML in `[checks|templates] list --format markdown` output
- remove `Parameters` section when there is no parameters  

Closes: #192 as we don't have JSON in our docs anymore