### PR TITLE
ci: use cache for Go modules and build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,8 @@ jobs:
         name: Run unit tests
         command: |
           GOMAXPROCS=1 make test
+    - *saveGoBuildCache
+    - *saveGoModCache
 
   build:
     executor: custom
@@ -88,8 +90,6 @@ jobs:
           make build
 
     - check-binary-version-match
-    - *saveGoBuildCache
-    - *saveGoModCache
 
     - run:
         name: Create a GitHub release, if on tag.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,34 @@
+goModCacheKey: &goModCacheKey 'rox-go-binary-pkg-mod-v2-{{ checksum "go.sum" }}'
+restoreGoModCache: &restoreGoModCache
+  restore_cache:
+    name: Restore Go module cache
+    keys:
+      - *goModCacheKey
+
+saveGoModCache: &saveGoModCache
+  save_cache:
+    name: Saving Go module cache
+    key: *goModCacheKey
+    paths:
+      - /home/circleci/go/pkg/mod
+
+restoreGoBuildCache: &restoreGoBuildCache
+  restore_cache:
+    name: Restoring Go build cache
+    keys:
+      - go-cache-v1-{{ .Environment.CIRCLE_JOB }}-{{ .Branch }}-{{ .Revision }}
+      - go-cache-v1-{{ .Environment.CIRCLE_JOB }}-{{ .Branch }}-
+      - go-cache-v1-{{ .Environment.CIRCLE_JOB }}-master-
+      - go-cache-v1-{{ .Environment.CIRCLE_JOB }}-
+      - go-cache-v1-
+
+saveGoBuildCache: &saveGoBuildCache
+  save_cache:
+    name: Saving Go build cache
+    key: go-cache-v1-{{ .Environment.CIRCLE_JOB }}-{{ .Branch }}-{{ .Revision }}
+    paths:
+      - /home/circleci/.cache/go-build
+
 orbs:
   win: circleci/windows@2.4.0
 
@@ -20,6 +51,8 @@ jobs:
     resource_class: large
     steps:
     - checkout
+    - *restoreGoBuildCache
+    - *restoreGoModCache
 
     - run:
         name: Run lint checks
@@ -36,6 +69,8 @@ jobs:
     executor: custom
     steps:
     - checkout
+    - *restoreGoBuildCache
+    - *restoreGoModCache
     - run:
         name: Run unit tests
         command: |
@@ -45,13 +80,16 @@ jobs:
     executor: custom
     steps:
     - checkout
-
+    - *restoreGoBuildCache
+    - *restoreGoModCache
     - run:
         name: Build binaries
         command: |
           make build
 
     - check-binary-version-match
+    - *saveGoBuildCache
+    - *saveGoModCache
 
     - run:
         name: Create a GitHub release, if on tag.


### PR DESCRIPTION
To speedup our CI let's use cache.
See: https://circleci.com/docs/2.0/language-go/