### PR TITLE
ci: use single proc for test to prevent OOM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
     - run:
         name: Run unit tests
         command: |
-          make test
+          GOMAXPROCS=1 make test
 
   build:
     executor: custom


### PR DESCRIPTION
Tests are failing with `signal: killed` in the logs.
This change will limit number of processors used to 1.

See: https://app.circleci.com/pipelines/github/stackrox/kube-linter/787/workflows/1f5c1ee8-1d23-4015-b324-0c4fb8137707/jobs/3367/steps