### PR TITLE
Do not run sarif test on dependabot updates

### DIFF
--- a/.github/workflows/bats-e2e.yaml
+++ b/.github/workflows/bats-e2e.yaml
@@ -1,10 +1,8 @@
 name: Test kube-linter via BATS
 
 on:
-  pull_request:
-  push:
-    branches:
-      - main
+  - pull_request
+  - push
 
 jobs:
   build-and-test:

--- a/.github/workflows/bats-e2e.yaml
+++ b/.github/workflows/bats-e2e.yaml
@@ -1,8 +1,10 @@
 name: Test kube-linter via BATS
 
 on:
-  - pull_request
-  - push
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   build-and-test:

--- a/.github/workflows/test-sarif.yaml
+++ b/.github/workflows/test-sarif.yaml
@@ -13,9 +13,10 @@ on:
   pull_request:
   # `push` event type should also be turned on in order for GitHub to be able to figure out diff between alerts in
   # source and target branches of PR and display it in Actions | Code scanning results.
+  # Workflows triggered by Dependabot on the "push" event run with read-only access and uploading Code Scanning results
+  # requires write access.
   push:
-    branches:
-      - main
+    branches-ignore: "dependabot/**"
 
 jobs:
   build-and-test:

--- a/.github/workflows/test-sarif.yaml
+++ b/.github/workflows/test-sarif.yaml
@@ -10,10 +10,12 @@ on:
   # See info here https://docs.github.com/en/rest/reference/code-scanning#upload-an-analysis-as-sarif-data
   # Although not documented officially, `pull_request` event type will make `github.ref` in PR format.
   # See https://frontside.com/blog/2020-05-26-github-actions-pull_request/#how-does-pull_request-affect-actionscheckout
-  - pull_request
+  pull_request:
   # `push` event type should also be turned on in order for GitHub to be able to figure out diff between alerts in
   # source and target branches of PR and display it in Actions | Code scanning results.
-  - push
+  push:
+    branches:
+      - main
 
 jobs:
   build-and-test:


### PR DESCRIPTION
> Error: Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches. See https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push for more information on how to configure these events.