### PR TITLE
Move test,lint,e2e to GH action

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,38 +46,6 @@ runOnAllTags: &runOnAllTags
 version: 2.1
 
 jobs:
-  lint:
-    executor: custom
-    resource_class: large
-    steps:
-    - checkout
-    - *restoreGoBuildCache
-    - *restoreGoModCache
-
-    - run:
-        name: Run lint checks
-        command: |
-          make lint
-
-    - run:
-        name: Ensure generated files are up-to-date
-        command: |
-          make generated-srcs
-          git diff --exit-code HEAD
-
-  test:
-    executor: custom
-    steps:
-    - checkout
-    - *restoreGoBuildCache
-    - *restoreGoModCache
-    - run:
-        name: Run unit tests
-        command: |
-          GOMAXPROCS=1 make test
-    - *saveGoBuildCache
-    - *saveGoModCache
-
   build:
     executor: custom
     steps:
@@ -125,31 +93,6 @@ jobs:
           name: Run E2E tests
           command: |
             make e2e-test
-
-  sanity-test-windows:
-    executor:
-      name: win/default  # references orb defined above.
-      size: "medium"
-
-    steps:
-      - checkout
-      - attach_workspace:
-          at: /home/circleci/kube-linter
-
-      - run:
-          name: Run E2E tests
-          shell: bash.exe
-          command: |
-            # In Windows, the workspace is attached relative to the current directory.
-            tag="$(./get-tag)"
-            cd home/circleci/kube-linter/bin/windows
-            version_from_bin="$(./kube-linter.exe version)"
-            echo "Expected tag ${tag}, got ${version_from_bin}"
-            [[ "${tag}" == "${version_from_bin}" ]]
-
-            # Make sure the lint command can run without errors.
-            # TODO: run the full suite of E2E tests on Windows.
-            ./kube-linter.exe lint .
 
   image:
     executor: custom
@@ -235,20 +178,8 @@ workflows:
   version: 2
   build:
     jobs:
-    - lint:
-        <<: *runOnAllTags
-    - test:
-        <<: *runOnAllTags
     - build:
         <<: *runOnAllTags
-    - e2e-test:
-        <<: *runOnAllTags
-        requires:
-          - build
-    - sanity-test-windows:
-        <<: *runOnAllTags
-        requires:
-          - build
     - image:
         <<: *runOnAllTags
         context: docker-io-push

--- a/.github/workflows/bats-e2e.yaml
+++ b/.github/workflows/bats-e2e.yaml
@@ -5,8 +5,11 @@ on:
   - push
 
 jobs:
-  build-and-test:
-    runs-on: ubuntu-latest
+  bats:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,13 +23,13 @@ jobs:
       - name: Go Build Cache
         uses: actions/cache@v2
         with:
-          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          path: ~/.cache
           key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
 
       - name: Go Mod Cache
         uses: actions/cache@v2
         with:
-          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
       - name: Build binaries
@@ -91,4 +91,4 @@ jobs:
 
           # Make sure the lint command can run without errors.
           # TODO: run the full suite of E2E tests on Windows.
-          ./kube-linter.exe lint tests\checks\access-to-create-pods.yml
+          ./kube-linter.exe lint "tests/checks/access-to-create-pods.yml"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,13 +20,17 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Cache Go modules
+      - name: Go Build Cache
         uses: actions/cache@v2
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+
+      - name: Go Mod Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
       - name: Build binaries
         run: make build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -91,4 +91,4 @@ jobs:
 
           # Make sure the lint command can run without errors.
           # TODO: run the full suite of E2E tests on Windows.
-          ./kube-linter.exe lint .
+          ./kube-linter.exe lint tests\checks\access-to-create-pods.yml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Test kube-linter via BATS
+name: Test kube-linter
 
 on:
   - pull_request
@@ -15,7 +15,6 @@ jobs:
 
       - name: Read Go version from go.mod
         run: echo "GO_VERSION=$(grep -E "^go\s+[0-9.]+$" go.mod | cut -d " " -f 2)" >> $GITHUB_ENV
-
       - name: Setup Go environment
         uses: actions/setup-go@v2
         with:
@@ -32,13 +31,22 @@ jobs:
       - name: Build binaries
         run: make build
 
-      - name: Print kube-linter version
-        run: .gobin/kube-linter version
+      - name: Verify the binary version
+        run: |
+          expected_version="$(./get-tag)"
+          version_from_binary="$(.gobin/kube-linter version)"
+          echo "Version from kube-linter binary: ${version_from_binary}. Expected version: ${expected_version}"
+          [[ "${version_from_binary}" == "${expected_version}" ]]
 
-      - name: Setup BATS
-        uses: mig4/setup-bats@v1
-        with:
-          bats-version: 1.5.0
+      - name: Run lint checks
+        run: make lint
 
-      - name: Run bats tests
-        run: make e2e-bats
+      - name: Ensure generated files are up-to-date
+        run: make generated-srcs && git diff --exit-code HEAD
+
+      - name: Run unit tests
+        run: make test
+
+      - name: Run E2E tests
+        run: make e2e-test
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,6 +31,12 @@ jobs:
       - name: Build binaries
         run: make build
 
+      - name: Upload windows binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: kube-linter.exe
+          path: bin/windows/kube-linter.exe
+
       - name: Verify the binary version
         run: |
           expected_version="$(./get-tag)"
@@ -50,3 +56,35 @@ jobs:
       - name: Run E2E tests
         run: make e2e-test
 
+      - name: Setup BATS
+        uses: mig4/setup-bats@v1
+        with:
+          bats-version: 1.5.0
+
+      - name: Run bats tests
+        run: make e2e-bats
+
+  windows-sanity-test:
+    name: Windows sanity test
+    needs: build-and-test
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Checkout all repo history to make tags available for figuring out kube-linter version during build.
+          fetch-depth: 0
+      - name: Download windows executable
+        uses: actions/download-artifact@v2
+        with:
+          name: kube-linter.exe
+      - shell: bash
+        run: |
+          # In Windows, the workspace is attached relative to the current directory.
+          tag="$(./get-tag)"
+          version_from_bin="$(./kube-linter.exe version)"
+          echo "Expected tag ${tag}, got ${version_from_bin}"
+          [[ "${tag}" == "${version_from_bin}" ]]
+
+          # Make sure the lint command can run without errors.
+          # TODO: run the full suite of E2E tests on Windows.
+          ./kube-linter.exe lint .

--- a/e2etests/sanity_test.go
+++ b/e2etests/sanity_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 package e2etests
@@ -37,7 +38,7 @@ func TestKubeLinterWithBuiltInChecksDoesntCrashOnHelmChartsRepo(t *testing.T) {
 
 	chartsDir := filepath.Join(tmpDir, "charts")
 
-	gitCloneOut, err := exec.Command("git", "clone", "git@github.com:helm/charts.git", chartsDir).CombinedOutput()
+	gitCloneOut, err := exec.Command("git", "clone", "https://github.com/helm/charts.git", chartsDir).CombinedOutput()
 	require.NoError(t, err, "Git clone failed. output: %s", string(gitCloneOut))
 
 	kubeLinterOut, err := exec.Command(kubeLinterBin, "lint", chartsDir, "--config", "testdata/all-built-in-config.yaml").CombinedOutput()


### PR DESCRIPTION
Since we have issues with running CircleCI for external contributors and we already use github actions let's move CI to gh actions. This PR runs build, lint, test, test e2e and bats on GH actions. We need to move pushing images to docker registries #125 and create release and this will finish the migration from CircleCi.