### PR TITLE
Add support for all current autoscaler hpa versions

### DIFF
--- a/pkg/extract/hpa_spec.go
+++ b/pkg/extract/hpa_spec.go
@@ -2,17 +2,32 @@ package extract
 
 import (
 	"golang.stackrox.io/kube-linter/pkg/k8sutil"
+	autoscalingV1 "k8s.io/api/autoscaling/v1"
+	autoscalingV2 "k8s.io/api/autoscaling/v2"
 	autoscalingV2Beta1 "k8s.io/api/autoscaling/v2beta1"
+	autoscalingV2Beta2 "k8s.io/api/autoscaling/v2beta2"
 )
 
 // HPAMinReplicas extracts minReplicas from the given object, if available.
 func HPAMinReplicas(obj k8sutil.Object) (int32, bool) {
-	if hpa, isHPA := obj.(*autoscalingV2Beta1.HorizontalPodAutoscaler); isHPA {
-		if hpa.Spec.MinReplicas != nil {
-			return *hpa.Spec.MinReplicas, true
-		}
-		// If numReplicas is a `nil` pointer, then it defaults to 1.
-		return 1, true
+	switch hpa := obj.(type) {
+	case *autoscalingV2Beta1.HorizontalPodAutoscaler:
+		return checkReplicas(hpa.Spec.MinReplicas)
+	case *autoscalingV2Beta2.HorizontalPodAutoscaler:
+		return checkReplicas(hpa.Spec.MinReplicas)
+	case *autoscalingV2.HorizontalPodAutoscaler:
+		return checkReplicas(hpa.Spec.MinReplicas)
+	case *autoscalingV1.HorizontalPodAutoscaler:
+		return checkReplicas(hpa.Spec.MinReplicas)
+	default:
+		return 0, false
 	}
-	return 0, false
+}
+
+func checkReplicas(minReplicas *int32) (int32, bool) {
+	if minReplicas != nil {
+		return *minReplicas, true
+	}
+	// If numReplicas is a `nil` pointer, then it defaults to 1.
+	return 1, true
 }

--- a/pkg/lintcontext/mocks/horizontalpodautoscaler.go
+++ b/pkg/lintcontext/mocks/horizontalpodautoscaler.go
@@ -1,30 +1,88 @@
 package mocks
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"golang.stackrox.io/kube-linter/pkg/objectkinds"
+	autoscalingV1 "k8s.io/api/autoscaling/v1"
+	autoscalingV2 "k8s.io/api/autoscaling/v2"
 	autoscalingV2Beta1 "k8s.io/api/autoscaling/v2beta1"
+	autoscalingV2Beta2 "k8s.io/api/autoscaling/v2beta2"
+
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // AddMockHorizontalPodAutoscaler adds a mock HorizontalPodAutoscaler to LintContext
-func (l *MockLintContext) AddMockHorizontalPodAutoscaler(t *testing.T, name string) {
+func (l *MockLintContext) AddMockHorizontalPodAutoscaler(t *testing.T, name, version string) {
 	require.NotEmpty(t, name)
-	l.objects[name] = &autoscalingV2Beta1.HorizontalPodAutoscaler{
-		TypeMeta: metaV1.TypeMeta{
-			Kind:       objectkinds.HorizontalPodAutoscaler,
-			APIVersion: objectkinds.GetHorizontalPodAutoscalerAPIVersion(),
-		},
-		ObjectMeta: metaV1.ObjectMeta{Name: name},
-		Spec:       autoscalingV2Beta1.HorizontalPodAutoscalerSpec{},
+	switch version {
+	case "v2beta1":
+		l.objects[name] = &autoscalingV2Beta1.HorizontalPodAutoscaler{
+			TypeMeta: metaV1.TypeMeta{
+				Kind:       objectkinds.HorizontalPodAutoscaler,
+				APIVersion: objectkinds.GetHorizontalPodAutoscalerAPIVersion(version),
+			},
+			ObjectMeta: metaV1.ObjectMeta{Name: name},
+			Spec:       autoscalingV2Beta1.HorizontalPodAutoscalerSpec{},
+		}
+	case "v2beta2":
+		l.objects[name] = &autoscalingV2Beta2.HorizontalPodAutoscaler{
+			TypeMeta: metaV1.TypeMeta{
+				Kind:       objectkinds.HorizontalPodAutoscaler,
+				APIVersion: objectkinds.GetHorizontalPodAutoscalerAPIVersion(version),
+			},
+			ObjectMeta: metaV1.ObjectMeta{Name: name},
+			Spec:       autoscalingV2Beta2.HorizontalPodAutoscalerSpec{},
+		}
+	case "v2":
+		l.objects[name] = &autoscalingV2.HorizontalPodAutoscaler{
+			TypeMeta: metaV1.TypeMeta{
+				Kind:       objectkinds.HorizontalPodAutoscaler,
+				APIVersion: objectkinds.GetHorizontalPodAutoscalerAPIVersion(version),
+			},
+			ObjectMeta: metaV1.ObjectMeta{Name: name},
+			Spec:       autoscalingV2.HorizontalPodAutoscalerSpec{},
+		}
+	case "v1":
+		l.objects[name] = &autoscalingV1.HorizontalPodAutoscaler{
+			TypeMeta: metaV1.TypeMeta{
+				Kind:       objectkinds.HorizontalPodAutoscaler,
+				APIVersion: objectkinds.GetHorizontalPodAutoscalerAPIVersion(version),
+			},
+			ObjectMeta: metaV1.ObjectMeta{Name: name},
+			Spec:       autoscalingV1.HorizontalPodAutoscalerSpec{},
+		}
+	default:
+		require.FailNow(t, fmt.Sprintf("Unknown autoscaling version %s", version))
 	}
 }
 
-//ModifyHorizontalPodAutoscaler modifies a given HorizontalPodAutoscaler in the context via the passed function.
-func (l *MockLintContext) ModifyHorizontalPodAutoscaler(t *testing.T, name string, f func(hpa *autoscalingV2Beta1.HorizontalPodAutoscaler)) {
+//ModifyHorizontalPodAutoscalerV2Beta1 modifies a given HorizontalPodAutoscaler in the context via the passed function.
+func (l *MockLintContext) ModifyHorizontalPodAutoscalerV2Beta1(t *testing.T, name string, f func(hpa *autoscalingV2Beta1.HorizontalPodAutoscaler)) {
 	r, ok := l.objects[name].(*autoscalingV2Beta1.HorizontalPodAutoscaler)
+	require.True(t, ok)
+	f(r)
+}
+
+//ModifyHorizontalPodAutoscalerV2Beta2 modifies a given HorizontalPodAutoscaler in the context via the passed function.
+func (l *MockLintContext) ModifyHorizontalPodAutoscalerV2Beta2(t *testing.T, name string, f func(hpa *autoscalingV2Beta2.HorizontalPodAutoscaler)) {
+	r, ok := l.objects[name].(*autoscalingV2Beta2.HorizontalPodAutoscaler)
+	require.True(t, ok)
+	f(r)
+}
+
+//ModifyHorizontalPodAutoscalerV2 modifies a given HorizontalPodAutoscaler in the context via the passed function.
+func (l *MockLintContext) ModifyHorizontalPodAutoscalerV2(t *testing.T, name string, f func(hpa *autoscalingV2.HorizontalPodAutoscaler)) {
+	r, ok := l.objects[name].(*autoscalingV2.HorizontalPodAutoscaler)
+	require.True(t, ok)
+	f(r)
+}
+
+//ModifyHorizontalPodAutoscalerV1 modifies a given HorizontalPodAutoscaler in the context via the passed function.
+func (l *MockLintContext) ModifyHorizontalPodAutoscalerV1(t *testing.T, name string, f func(hpa *autoscalingV1.HorizontalPodAutoscaler)) {
+	r, ok := l.objects[name].(*autoscalingV1.HorizontalPodAutoscaler)
 	require.True(t, ok)
 	f(r)
 }

--- a/pkg/objectkinds/horizontalpodautoscaler.go
+++ b/pkg/objectkinds/horizontalpodautoscaler.go
@@ -3,7 +3,10 @@ package objectkinds
 import (
 	"fmt"
 
+	autoscalingV1 "k8s.io/api/autoscaling/v1"
+	autoscalingV2 "k8s.io/api/autoscaling/v2"
 	autoscalingV2Beta1 "k8s.io/api/autoscaling/v2beta1"
+	autoscalingV2Beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -13,16 +16,24 @@ const (
 )
 
 var (
-	horizontalPodAutoscalerGVK = autoscalingV2Beta1.SchemeGroupVersion.WithKind("HorizontalPodAutoscaler")
+	horizontalPodAutoscalerV2Beta1GVK = autoscalingV2Beta1.SchemeGroupVersion.WithKind(HorizontalPodAutoscaler)
+	horizontalPodAutoscalerV2Beta2GVK = autoscalingV2Beta2.SchemeGroupVersion.WithKind(HorizontalPodAutoscaler)
+	horizontalPodAutoscalerV2GVK      = autoscalingV2.SchemeGroupVersion.WithKind(HorizontalPodAutoscaler)
+	horizontalPodAutoscalerV1GVK      = autoscalingV1.SchemeGroupVersion.WithKind(HorizontalPodAutoscaler)
 )
 
+func isHorizontalPodAutoscaler(gvk schema.GroupVersionKind) bool {
+	return gvk == horizontalPodAutoscalerV1GVK ||
+		gvk == horizontalPodAutoscalerV2GVK ||
+		gvk == horizontalPodAutoscalerV2Beta1GVK ||
+		gvk == horizontalPodAutoscalerV2Beta2GVK
+}
+
 func init() {
-	registerObjectKind(HorizontalPodAutoscaler, matcherFunc(func(gvk schema.GroupVersionKind) bool {
-		return gvk == horizontalPodAutoscalerGVK
-	}))
+	registerObjectKind(HorizontalPodAutoscaler, matcherFunc(isHorizontalPodAutoscaler))
 }
 
 // GetHorizontalPodAutoscalerAPIVersion returns HorizontalPodAutoscaler's APIVersion
-func GetHorizontalPodAutoscalerAPIVersion() string {
-	return fmt.Sprintf("%s/%s", horizontalPodAutoscalerGVK.Group, horizontalPodAutoscalerGVK.Version)
+func GetHorizontalPodAutoscalerAPIVersion(version string) string {
+	return fmt.Sprintf("%s/%s", horizontalPodAutoscalerV2Beta1GVK.Group, version)
 }

--- a/pkg/templates/hpareplicas/template_test.go
+++ b/pkg/templates/hpareplicas/template_test.go
@@ -1,15 +1,23 @@
 package hpareplicas
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/suite"
 	"golang.stackrox.io/kube-linter/pkg/diagnostic"
 	"golang.stackrox.io/kube-linter/pkg/lintcontext/mocks"
 	"golang.stackrox.io/kube-linter/pkg/templates"
 	"golang.stackrox.io/kube-linter/pkg/templates/hpareplicas/internal/params"
+	autoscalingV1 "k8s.io/api/autoscaling/v1"
+	autoscalingV2 "k8s.io/api/autoscaling/v2"
 	autoscalingV2Beta1 "k8s.io/api/autoscaling/v2beta1"
+	autoscalingV2Beta2 "k8s.io/api/autoscaling/v2beta2"
 )
+
+var autoscalingVersions = [4]string{"v2beta1", "v2beta2", "v2", "v1"}
 
 func TestHPAReplicas(t *testing.T) {
 	suite.Run(t, new(HPAReplicaTestSuite))
@@ -26,11 +34,28 @@ func (s *HPAReplicaTestSuite) SetupTest() {
 	s.ctx = mocks.NewMockContext()
 }
 
-func (s *HPAReplicaTestSuite) addHPAWithReplicas(name string, replicas int32) {
-	s.ctx.AddMockHorizontalPodAutoscaler(s.T(), name)
-	s.ctx.ModifyHorizontalPodAutoscaler(s.T(), name, func(hpa *autoscalingV2Beta1.HorizontalPodAutoscaler) {
-		hpa.Spec.MinReplicas = &replicas
-	})
+func (s *HPAReplicaTestSuite) addHPAWithReplicas(name string, replicas int32, version string) {
+	s.ctx.AddMockHorizontalPodAutoscaler(s.T(), name, version)
+	switch version {
+	case "v2beta1":
+		s.ctx.ModifyHorizontalPodAutoscalerV2Beta1(s.T(), name, func(hpa *autoscalingV2Beta1.HorizontalPodAutoscaler) {
+			hpa.Spec.MinReplicas = &replicas
+		})
+	case "v2beta2":
+		s.ctx.ModifyHorizontalPodAutoscalerV2Beta2(s.T(), name, func(hpa *autoscalingV2Beta2.HorizontalPodAutoscaler) {
+			hpa.Spec.MinReplicas = &replicas
+		})
+	case "v2":
+		s.ctx.ModifyHorizontalPodAutoscalerV2(s.T(), name, func(hpa *autoscalingV2.HorizontalPodAutoscaler) {
+			hpa.Spec.MinReplicas = &replicas
+		})
+	case "v1":
+		s.ctx.ModifyHorizontalPodAutoscalerV1(s.T(), name, func(hpa *autoscalingV1.HorizontalPodAutoscaler) {
+			hpa.Spec.MinReplicas = &replicas
+		})
+	default:
+		require.FailNow(s.T(), fmt.Sprintf("Unknown autoscaling version %s", version))
+	}
 }
 
 func (s *HPAReplicaTestSuite) TestTooFewReplicas() {
@@ -39,42 +64,47 @@ func (s *HPAReplicaTestSuite) TestTooFewReplicas() {
 		twoReplicasHPAName        = "hpa-two-replicas"
 	)
 
-	s.ctx.AddMockHorizontalPodAutoscaler(s.T(), noExplicitReplicasHPAName)
-	s.addHPAWithReplicas(twoReplicasHPAName, 2)
+	for _, version := range autoscalingVersions {
+		s.ctx.AddMockHorizontalPodAutoscaler(s.T(), noExplicitReplicasHPAName, version)
+		s.addHPAWithReplicas(twoReplicasHPAName, 2, version)
 
-	s.Validate(s.ctx, []templates.TestCase{
-		{
-			Param: params.Params{
-				MinReplicas: 3,
-			},
-			Diagnostics: map[string][]diagnostic.Diagnostic{
-				noExplicitReplicasHPAName: {
-					{Message: "object has 1 replica but minimum required replicas is 3"},
+		s.Validate(s.ctx, []templates.TestCase{
+			{
+				Param: params.Params{
+					MinReplicas: 3,
 				},
-				twoReplicasHPAName: {
-					{Message: "object has 2 replicas but minimum required replicas is 3"},
+				Diagnostics: map[string][]diagnostic.Diagnostic{
+					noExplicitReplicasHPAName: {
+						{Message: "object has 1 replica but minimum required replicas is 3"},
+					},
+					twoReplicasHPAName: {
+						{Message: "object has 2 replicas but minimum required replicas is 3"},
+					},
 				},
+				ExpectInstantiationError: false,
 			},
-			ExpectInstantiationError: false,
-		},
-	})
+		})
+	}
 }
 
 func (s *HPAReplicaTestSuite) TestAcceptableReplicas() {
 	const (
 		acceptableReplicasHPAName = "hpa-acceptable-replicas"
 	)
-	s.addHPAWithReplicas(acceptableReplicasHPAName, 3)
 
-	s.Validate(s.ctx, []templates.TestCase{
-		{
-			Param: params.Params{
-				MinReplicas: 3,
+	for _, version := range autoscalingVersions {
+		s.addHPAWithReplicas(acceptableReplicasHPAName, 3, version)
+
+		s.Validate(s.ctx, []templates.TestCase{
+			{
+				Param: params.Params{
+					MinReplicas: 3,
+				},
+				Diagnostics: map[string][]diagnostic.Diagnostic{
+					acceptableReplicasHPAName: nil,
+				},
+				ExpectInstantiationError: false,
 			},
-			Diagnostics: map[string][]diagnostic.Diagnostic{
-				acceptableReplicasHPAName: nil,
-			},
-			ExpectInstantiationError: false,
-		},
-	})
+		})
+	}
 }


### PR DESCRIPTION
This adds support for all current autoscaler versions (v1, v2, v2beta1,
and v2beta2) for hpa and template to test minireplicas at least 3.

Fix issue: #287