### PR TITLE
Do not alert on missing readiness / liveness probe for init containers.

### DIFF
--- a/pkg/templates/livenessprobe/template.go
+++ b/pkg/templates/livenessprobe/template.go
@@ -24,7 +24,7 @@ func init() {
 		Parameters:             params.ParamDescs,
 		ParseAndValidateParams: params.ParseAndValidate,
 		Instantiate: params.WrapInstantiateFunc(func(_ params.Params) (check.Func, error) {
-			return util.PerContainerCheck(func(container *v1.Container) []diagnostic.Diagnostic {
+			return util.PerNonInitContainerCheck(func(container *v1.Container) []diagnostic.Diagnostic {
 				if container.LivenessProbe == nil {
 					return []diagnostic.Diagnostic{{Message: fmt.Sprintf("container %q does not specify a liveness probe", container.Name)}}
 				}

--- a/pkg/templates/readinessprobe/template.go
+++ b/pkg/templates/readinessprobe/template.go
@@ -24,7 +24,7 @@ func init() {
 		Parameters:             params.ParamDescs,
 		ParseAndValidateParams: params.ParseAndValidate,
 		Instantiate: params.WrapInstantiateFunc(func(_ params.Params) (check.Func, error) {
-			return util.PerContainerCheck(func(container *v1.Container) []diagnostic.Diagnostic {
+			return util.PerNonInitContainerCheck(func(container *v1.Container) []diagnostic.Diagnostic {
 				if container.ReadinessProbe == nil {
 					return []diagnostic.Diagnostic{{Message: fmt.Sprintf("container %q does not specify a readiness probe", container.Name)}}
 				}

--- a/pkg/templates/util/per_container_check.go
+++ b/pkg/templates/util/per_container_check.go
@@ -25,3 +25,21 @@ func PerContainerCheck(matchFunc func(container *v1.Container) []diagnostic.Diag
 		return results
 	}
 }
+
+// PerNonInitContainerCheck returns a check that abstracts away some of the boilerplate of writing a check
+// that applies to all non-init containers. The given function is passed each non-init container,
+// and is allowed to return diagnostics if an error is found.
+func PerNonInitContainerCheck(matchFunc func(container *v1.Container) []diagnostic.Diagnostic) check.Func {
+	return func(_ lintcontext.LintContext, object lintcontext.Object) []diagnostic.Diagnostic {
+		podSpec, found := extract.PodSpec(object.K8sObject)
+		if !found {
+			return nil
+		}
+		var results []diagnostic.Diagnostic
+		containers := podSpec.NonInitContainers()
+		for i := range containers {
+			results = append(results, matchFunc(&containers[i])...)
+		}
+		return results
+	}
+}

--- a/tests/checks/no-liveness-probe.yml
+++ b/tests/checks/no-liveness-probe.yml
@@ -52,3 +52,22 @@ spec:
     spec:
       containers:
       - name: app2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: some-container
+      containers:
+        - name: app
+          livenessProbe:
+            exec:
+              command:
+                - cat
+                - /tmp/healthy
+            initialDelaySeconds: 5
+            periodSeconds: 5

--- a/tests/checks/no-readiness-probe.yml
+++ b/tests/checks/no-readiness-probe.yml
@@ -52,3 +52,22 @@ spec:
     spec:
       containers:
       - name: app
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: some-container
+      containers:
+        - name: app
+          readinessProbe:
+            exec:
+              command:
+                - cat
+                - /tmp/healthy
+            initialDelaySeconds: 5
+            periodSeconds: 5


### PR DESCRIPTION
Create new util function `PerNonInitContainer`, which will skip init containers from being taken into account for readiness / liveness probe checks, as [init containers cannot specify them according to the pod spec.](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec)

Closes #261 