### PR TITLE
Ignore dependabot branches.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,8 +1,11 @@
 name: Test kube-linter
 
 on:
-  - pull_request
-  - push
+  pull_request:
+  # Workflows triggered by Dependabot on the "push" event run with read-only access.
+  # Uploading Code Scanning results requires write access. Ignore dependabot branches for auto-merge.
+  push:
+    branches-ignore: "dependabot/**"
 
 env:
   # Use docker.io for Docker Hub if empty


### PR DESCRIPTION
Currently dependabot branches CI is failing. We execute `test sarif` on push events which requires write access, dependabot only has read access on push events.

Skipping dependabot branches' push event to avoid failing the CI.