### PR TITLE
Remove if condition, handled by ignore-branches now.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -119,8 +119,6 @@ jobs:
           ./yajsv -s ./scripts/sarif/sarif-schema-2.1.0.json results.sarif
 
       - name: Upload SARIF output file to GitHub
-        # Workflows triggered by Dependabot on the "push" event run with read-only access and uploading Code Scanning results requires write access.
-        if: ((github.event_name == 'push') && !contains(github.head_ref, 'dependabot')) || (github.event_name != 'push')
         uses: github/codeql-action/upload-sarif@v1
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Removing remaining line in CI workflow, not needed anymore since we handle the dependabot branches via `branches-ignore`.