### PR TITLE
Be more clear with errors found within anti-affinity rules.

### DIFF
--- a/pkg/templates/antiaffinity/template.go
+++ b/pkg/templates/antiaffinity/template.go
@@ -2,6 +2,7 @@ package antiaffinity
 
 import (
 	"fmt"
+	"strings"
 
 	"golang.stackrox.io/kube-linter/internal/stringutils"
 	"golang.stackrox.io/kube-linter/pkg/check"
@@ -28,9 +29,10 @@ func defaultTopologyKeyMatcher(topologyKey string) bool {
 
 func init() {
 	templates.Register(check.Template{
-		HumanName:   "Anti affinity not specified",
-		Key:         templateKey,
-		Description: "Flag objects with multiple replicas but inter-pod anti affinity not specified in the pod template spec",
+		HumanName: "Anti affinity not specified",
+		Key:       templateKey,
+		Description: "Flag objects with multiple replicas but inter-pod anti affinity not specified in the pod " +
+			"template spec",
 		SupportedObjectKinds: config.ObjectKindsDesc{
 			ObjectKinds: []string{objectkinds.DeploymentLike},
 		},
@@ -59,30 +61,47 @@ func init() {
 				if !hasPods {
 					return nil
 				}
+				var foundIssues []diagnostic.Diagnostic
 				if affinity := podTemplateSpec.Spec.Affinity; affinity != nil && affinity.PodAntiAffinity != nil {
 					preferredAffinity := affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
 					requiredAffinity := affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
 					for _, preferred := range preferredAffinity {
-						if affinityTermMatchesLabelsAgainstNodes(preferred.PodAffinityTerm, podTemplateSpec.Namespace, podTemplateSpec.Labels, topologyKeyMatcher) {
+						err := affinityTermMatchesLabelsAgainstNodes(preferred.PodAffinityTerm,
+							podTemplateSpec.Namespace, podTemplateSpec.Labels, topologyKeyMatcher)
+						if err == nil {
 							return nil
 						}
+						foundIssues = append(foundIssues, diagnostic.Diagnostic{
+							Message: err.Error(),
+						})
 					}
 					for _, required := range requiredAffinity {
-						if affinityTermMatchesLabelsAgainstNodes(required, podTemplateSpec.Namespace, podTemplateSpec.Labels, topologyKeyMatcher) {
+						err := affinityTermMatchesLabelsAgainstNodes(required, podTemplateSpec.Namespace,
+							podTemplateSpec.Labels, topologyKeyMatcher)
+						if err == nil {
 							return nil
 						}
+						foundIssues = append(foundIssues, diagnostic.Diagnostic{
+							Message: err.Error(),
+						})
 					}
 				}
+				if foundIssues != nil {
+					return foundIssues
+				}
 				return []diagnostic.Diagnostic{
-					{Message: fmt.Sprintf("object has %d %s but does not specify inter pod anti-affinity", replicas, stringutils.Ternary(replicas > 1, "replicas", "replica"))},
+					{Message: fmt.Sprintf("object has %d %s but does not specify inter pod anti-affinity",
+						replicas, stringutils.Ternary(replicas > 1, "replicas", "replica"))},
 				}
 			}, nil
 		}),
 	})
 }
 
-func affinityTermMatchesLabelsAgainstNodes(affinityTerm coreV1.PodAffinityTerm, podNamespace string, podLabels map[string]string, topologyKeyMatcher func(string) bool) bool {
-	// If namespaces is not specified in the affinity term, that means the affinity term implicitly applies to the pod's namespace.
+func affinityTermMatchesLabelsAgainstNodes(affinityTerm coreV1.PodAffinityTerm, podNamespace string,
+	podLabels map[string]string, topologyKeyMatcher func(string) bool) error {
+	// If namespaces is not specified in the affinity term, that means the affinity term implicitly applies to
+	// the pod's namespace.
 	if len(affinityTerm.Namespaces) > 0 {
 		var matchingNSFound bool
 		for _, ns := range affinityTerm.Namespaces {
@@ -92,15 +111,21 @@ func affinityTermMatchesLabelsAgainstNodes(affinityTerm coreV1.PodAffinityTerm, 
 			}
 		}
 		if !matchingNSFound {
-			return false
+			return fmt.Errorf("pod's namespace %q not found in anti-affinity's namespaces [%s]",
+				podNamespace, strings.Join(affinityTerm.Namespaces, ", "))
 		}
 	}
 	labelSelector, err := metaV1.LabelSelectorAsSelector(affinityTerm.LabelSelector)
 	if err != nil {
-		return false
+		return err
 	}
-	if topologyKeyMatcher(affinityTerm.TopologyKey) && labelSelector.Matches(labels.Set(podLabels)) {
-		return true
+
+	if !topologyKeyMatcher(affinityTerm.TopologyKey) {
+		return fmt.Errorf("anti-affinity's topology key does not match %q", affinityTerm.TopologyKey)
 	}
-	return false
+	if !labelSelector.Matches(labels.Set(podLabels)) {
+		return fmt.Errorf("pod's labels %q do not match with anti-affinity's labels %q",
+			labels.Set(podLabels).String(), labelSelector.String())
+	}
+	return nil
 }

--- a/pkg/templates/antiaffinity/template.go
+++ b/pkg/templates/antiaffinity/template.go
@@ -73,7 +73,7 @@ func init() {
 				preferredAffinity := affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
 				requiredAffinity := affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
 				for _, preferred := range preferredAffinity {
-					err := affinityTermMatchesLabelsAgainstNodes(preferred.PodAffinityTerm,
+					err := validateAffinityTermMatchesAgainstNodes(preferred.PodAffinityTerm,
 						podTemplateSpec.Namespace, podTemplateSpec.Labels, topologyKeyMatcher)
 					if err != nil {
 						foundIssues = append(foundIssues, diagnostic.Diagnostic{
@@ -82,7 +82,7 @@ func init() {
 					}
 				}
 				for _, required := range requiredAffinity {
-					err := affinityTermMatchesLabelsAgainstNodes(required, podTemplateSpec.Namespace,
+					err := validateAffinityTermMatchesAgainstNodes(required, podTemplateSpec.Namespace,
 						podTemplateSpec.Labels, topologyKeyMatcher)
 					if err != nil {
 						foundIssues = append(foundIssues, diagnostic.Diagnostic{
@@ -90,16 +90,13 @@ func init() {
 						})
 					}
 				}
-				if foundIssues != nil {
-					return foundIssues
-				}
-				return nil
+				return foundIssues
 			}, nil
 		}),
 	})
 }
 
-func affinityTermMatchesLabelsAgainstNodes(affinityTerm coreV1.PodAffinityTerm, podNamespace string,
+func validateAffinityTermMatchesAgainstNodes(affinityTerm coreV1.PodAffinityTerm, podNamespace string,
 	podLabels map[string]string, topologyKeyMatcher func(string) bool) error {
 	// If namespaces is not specified in the affinity term, that means the affinity term implicitly applies to
 	// the pod's namespace.


### PR DESCRIPTION
Fixes #286 .

Now, more specific errors will be returned when running checks against anti-affinity rules that have misconfigurations:

- Pod's and pod affinity's namespaces are not matching: `pod's namespace "pod-namespace" not found in anti-affinity's namespaces [affinity-namespace]`
- Topology key does not match: `anti-affinity's topology key does not match "some.key/value"`
- Pod's and pod affinity's labels are not matching: `pod's labels \"pod=labels\" do not match with anti-affinity's labels \"anti-affinity=labels\"`