### PR TITLE
Add new flag to force color output.

### DIFF
--- a/pkg/command/root/command.go
+++ b/pkg/command/root/command.go
@@ -1,10 +1,10 @@
 package root
 
 import (
-	"github.com/fatih/color"
 	"os"
 	"path/filepath"
 
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"golang.stackrox.io/kube-linter/pkg/command/checks"
 	"golang.stackrox.io/kube-linter/pkg/command/lint"

--- a/pkg/command/root/command.go
+++ b/pkg/command/root/command.go
@@ -1,6 +1,7 @@
 package root
 
 import (
+	"github.com/fatih/color"
 	"os"
 	"path/filepath"
 
@@ -11,12 +12,22 @@ import (
 	"golang.stackrox.io/kube-linter/pkg/command/version"
 )
 
+const (
+	colorFlag = "with-color"
+)
+
 // Command is the root command.
 func Command() *cobra.Command {
 	c := &cobra.Command{
 		Use:           filepath.Base(os.Args[0]),
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
+			// Only forcefully set colorful output if the flag has been set.
+			if cmd.Flags().Changed(colorFlag) {
+				color.NoColor = false
+			}
+		},
 	}
 	c.AddCommand(
 		checks.Command(),
@@ -24,5 +35,6 @@ func Command() *cobra.Command {
 		templates.Command(),
 		version.Command(),
 	)
+	c.PersistentFlags().Bool(colorFlag, true, "Force color output")
 	return c
 }

--- a/pkg/command/root/command_test.go
+++ b/pkg/command/root/command_test.go
@@ -1,0 +1,22 @@
+package root
+
+import (
+	"fmt"
+	"github.com/fatih/color"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io"
+	"testing"
+)
+
+func TestCommand(t *testing.T) {
+	c := Command()
+	c.SetOut(io.Discard)
+	c.SetArgs([]string{
+		"version",
+		fmt.Sprintf("--%s", colorFlag),
+	})
+	err := c.Execute()
+	require.NoError(t, err)
+	assert.False(t, color.NoColor)
+}

--- a/pkg/command/root/command_test.go
+++ b/pkg/command/root/command_test.go
@@ -2,11 +2,12 @@ package root
 
 import (
 	"fmt"
+	"io"
+	"testing"
+
 	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"io"
-	"testing"
 )
 
 func TestCommand(t *testing.T) {


### PR DESCRIPTION
Closes #205 .

Added new flag `--with-color`, which will force color output even when used in non-terminal, i.e. scripts / CI.