### PR TITLE
Remove unused staticcheck import

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/spf13/viper v1.11.0
 	github.com/stretchr/testify v1.7.1
 	helm.sh/helm/v3 v3.9.0
-	honnef.co/go/tools v0.3.1
 	k8s.io/api v0.24.0
 	k8s.io/apimachinery v0.24.0
 	k8s.io/cli-runtime v0.24.0
@@ -233,6 +232,7 @@ require (
 	gopkg.in/ini.v1 v1.66.4 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	honnef.co/go/tools v0.3.1 // indirect
 	k8s.io/apiextensions-apiserver v0.24.0 // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect

--- a/tool-imports/tools.go
+++ b/tool-imports/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package toolimports
@@ -8,6 +9,5 @@ package toolimports
 
 import (
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
-	_ "honnef.co/go/tools/cmd/staticcheck"
 	_ "k8s.io/cli-runtime/pkg/resource" // This is imported because we want to be able to require it at a certain version, since otherwise Helm breaks.
 )


### PR DESCRIPTION
We imports static check but then use version from golang CI so we can safely remove it from our files.