### PR TITLE
Support check.ignorePaths config option

### DIFF
--- a/docs/configuring-kubelinter.md
+++ b/docs/configuring-kubelinter.md
@@ -48,7 +48,7 @@ checks:
 
 ## Ignore paths
 
-To ignore checks on files or direcotry under certain paths, add ignored paths to `ignorePaths`.
+To ignore checks on files or directories under certain paths, add ignored paths to `ignorePaths`.
 ```yaml
 checks:
   ignorePaths:

--- a/docs/configuring-kubelinter.md
+++ b/docs/configuring-kubelinter.md
@@ -46,6 +46,15 @@ checks:
   addAllBuiltIn: true
 ```
 
+## Ignore paths
+
+To ignore checks on files or direcotry under certain paths, add ignored paths to `ignorePaths`.
+```yaml
+checks:
+  ignorePaths:
+    - ~/foo/bar
+```
+
 > Equivalent CLI flag is `--add-all-built-in`
 
 > [!NOTE]

--- a/docs/configuring-kubelinter.md
+++ b/docs/configuring-kubelinter.md
@@ -53,6 +53,8 @@ To ignore checks on files or direcotry under certain paths, add ignored paths to
 checks:
   ignorePaths:
     - ~/foo/bar
+    - ../baz
+    - /tmp/*.yaml
 ```
 
 > Equivalent CLI flag is `--add-all-built-in`

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
+	github.com/bmatcuk/doublestar/v3 v3.0.0
 	github.com/fatih/color v1.13.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/golangci/golangci-lint v1.46.2

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/golangci/golangci-lint v1.46.2
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/owenrumney/go-sarif/v2 v2.1.1
@@ -146,7 +147,6 @@ require (
 	github.com/mbilski/exhaustivestruct v1.2.0 // indirect
 	github.com/mgechev/revive v1.2.1 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
-	github.com/bmatcuk/doublestar/v3 v3.0.0
+	github.com/bmatcuk/doublestar/v4 v4.0.3
 	github.com/fatih/color v1.13.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/golangci/golangci-lint v1.46.2

--- a/go.sum
+++ b/go.sum
@@ -147,6 +147,8 @@ github.com/bkielbasa/cyclop v1.2.0/go.mod h1:qOI0yy6A7dYC4Zgsa72Ppm9kONl0RoIlPbz
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/blizzy78/varnamelen v0.8.0 h1:oqSblyuQvFsW1hbBHh1zfwrKe3kcSj0rnXkKzsQ089M=
 github.com/blizzy78/varnamelen v0.8.0/go.mod h1:V9TzQZ4fLJ1DSrjVDfl89H7aMnTvKkApdHeyESmyR7k=
+github.com/bmatcuk/doublestar/v3 v3.0.0 h1:TQtVPlDnAYwcrVNB2JiGuMc++H5qzWZd9PhkNo5WyHI=
+github.com/bmatcuk/doublestar/v3 v3.0.0/go.mod h1:6PcTVMw80pCY1RVuoqu3V++99uQB3vsSYKPTd8AWA0k=
 github.com/bombsimon/wsl/v3 v3.3.0 h1:Mka/+kRLoQJq7g2rggtgQsjuI/K5Efd87WX96EWFxjM=
 github.com/bombsimon/wsl/v3 v3.3.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
 github.com/breml/bidichk v0.2.3 h1:qe6ggxpTfA8E75hdjWPZ581sY3a2lnl0IRxLQFelECI=

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/bkielbasa/cyclop v1.2.0/go.mod h1:qOI0yy6A7dYC4Zgsa72Ppm9kONl0RoIlPbz
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/blizzy78/varnamelen v0.8.0 h1:oqSblyuQvFsW1hbBHh1zfwrKe3kcSj0rnXkKzsQ089M=
 github.com/blizzy78/varnamelen v0.8.0/go.mod h1:V9TzQZ4fLJ1DSrjVDfl89H7aMnTvKkApdHeyESmyR7k=
-github.com/bmatcuk/doublestar/v3 v3.0.0 h1:TQtVPlDnAYwcrVNB2JiGuMc++H5qzWZd9PhkNo5WyHI=
-github.com/bmatcuk/doublestar/v3 v3.0.0/go.mod h1:6PcTVMw80pCY1RVuoqu3V++99uQB3vsSYKPTd8AWA0k=
+github.com/bmatcuk/doublestar/v4 v4.0.3 h1:4OP3JgX9zL4yBFezFv8AuFpxWkgp8pNV9A1FY4bVVN4=
+github.com/bmatcuk/doublestar/v4 v4.0.3/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bombsimon/wsl/v3 v3.3.0 h1:Mka/+kRLoQJq7g2rggtgQsjuI/K5Efd87WX96EWFxjM=
 github.com/bombsimon/wsl/v3 v3.3.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
 github.com/breml/bidichk v0.2.3 h1:qe6ggxpTfA8E75hdjWPZ581sY3a2lnl0IRxLQFelECI=

--- a/pkg/command/lint/command.go
+++ b/pkg/command/lint/command.go
@@ -81,7 +81,12 @@ func Command() *cobra.Command {
 				fmt.Fprintln(os.Stderr, "Warning: no checks enabled.")
 				return nil
 			}
-			lintCtxs, err := lintcontext.CreateContexts(args...)
+			ignorePaths, err := configresolver.GetIgnorepaths(&cfg)
+			if err != nil {
+				return err
+			}
+
+			lintCtxs, err := lintcontext.CreateContexts(ignorePaths, args...)
 			if err != nil {
 				return err
 			}

--- a/pkg/command/lint/command.go
+++ b/pkg/command/lint/command.go
@@ -81,7 +81,7 @@ func Command() *cobra.Command {
 				fmt.Fprintln(os.Stderr, "Warning: no checks enabled.")
 				return nil
 			}
-			ignorePaths, err := configresolver.GetIgnorepaths(&cfg)
+			ignorePaths, err := configresolver.GetIgnorePaths(&cfg)
 			if err != nil {
 				return err
 			}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,9 @@ type ChecksConfig struct {
 	// Exclude wins.
 	// +flagName=include
 	Include []string `json:"include"`
+	// IgnorePaths is a list of path to ignore from applying checks
+	// +flagName=excludePaths
+	IgnorePaths []string `json:"ignorePaths"`
 }
 
 // Config represents the config file format.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,7 +27,7 @@ type ChecksConfig struct {
 	// +flagName=include
 	Include []string `json:"include"`
 	// IgnorePaths is a list of path to ignore from applying checks
-	// +flagName=excludePaths
+	// +flagName=ignorePaths
 	IgnorePaths []string `json:"ignorePaths"`
 }
 

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -27,4 +27,8 @@ func AddFlags(c *cobra.Command, v *viper.Viper) {
 	if err := v.BindPFlag("checks.include", c.Flags().Lookup("include")); err != nil {
 		panic(err)
 	}
+	c.Flags().StringSlice("ignorePaths", nil, "IgnorePaths is a list of path to ignore from applying checks")
+	if err := v.BindPFlag("checks.ignorePaths", c.Flags().Lookup("ignorePaths")); err != nil {
+		panic(err)
+	}
 }

--- a/pkg/configresolver/config_resolver.go
+++ b/pkg/configresolver/config_resolver.go
@@ -64,25 +64,25 @@ func GetIgnorePaths(cfg *config.Config) ([]string, error) {
 	errorList := errorhelpers.NewErrorList("check ignore paths")
 	ignorePaths := set.NewStringSet()
 	for _, path := range cfg.Checks.IgnorePaths {
-		switch {
-		case path[0] == '~':
-			expandedPath, err := homedir.Expand(path)
+		if path[0] == '~' {
+			path, err := homedir.Expand(path)
 			if err != nil {
 				errorList.AddStringf("could not expand path: %q", path)
 				continue
 			}
-			ignorePaths.Add(expandedPath)
-		case !filepath.IsAbs(path):
-			absolutePath, err := filepath.Abs(path)
+		}
+
+		if !filepath.IsAbs(path) {
+			path, err := filepath.Abs(path)
 			if err != nil {
 				errorList.AddStringf("could not expand non-absolute path: %q", path)
 				continue
 			}
-			ignorePaths.Add(absolutePath)
-		default:
-			ignorePaths.Add(path)
 		}
+
+		ignorePaths.AddAll(path)
 	}
+
 	if err := errorList.ToError(); err != nil {
 		return nil, err
 	}

--- a/pkg/configresolver/config_resolver.go
+++ b/pkg/configresolver/config_resolver.go
@@ -64,23 +64,24 @@ func GetIgnorePaths(cfg *config.Config) ([]string, error) {
 	errorList := errorhelpers.NewErrorList("check ignore paths")
 	ignorePaths := set.NewStringSet()
 	for _, path := range cfg.Checks.IgnorePaths {
+		result := path
 		if path[0] == '~' {
-			path, err := homedir.Expand(path)
+			expandedPath, err := homedir.Expand(path)
 			if err != nil {
-				errorList.AddStringf("could not expand path: %q", path)
+				errorList.AddStringf("could not expand path: %q", expandedPath)
 				continue
 			}
-		}
-
-		if !filepath.IsAbs(path) {
-			path, err := filepath.Abs(path)
+			result = expandedPath
+		} else if !filepath.IsAbs(path) {
+			absPath, err := filepath.Abs(path)
 			if err != nil {
-				errorList.AddStringf("could not expand non-absolute path: %q", path)
+				errorList.AddStringf("could not expand non-absolute path: %q", absPath)
 				continue
 			}
+			result = absPath
 		}
 
-		ignorePaths.AddAll(path)
+		ignorePaths.AddAll(result)
 	}
 
 	if err := errorList.ToError(); err != nil {

--- a/pkg/configresolver/config_resolver.go
+++ b/pkg/configresolver/config_resolver.go
@@ -60,32 +60,33 @@ func GetEnabledChecksAndValidate(cfg *config.Config, checkRegistry checkregistry
 }
 
 // GetIgnorePaths loads the paths from the config into the check registry.
-func GetIgnorepaths(cfg *config.Config) ([]string, error) {
+func GetIgnorePaths(cfg *config.Config) ([]string, error) {
 	errorList := errorhelpers.NewErrorList("check ignore paths")
 	ignorePaths := set.NewStringSet()
-    for _, path := range cfg.Checks.IgnorePaths {
-        if path[0] == '~' {
-            expandedPath, err := homedir.Expand(path)
-            if err != nil {
-                errorList.AddStringf("could not expand path: %q", path)
-                continue
-            } 
-            ignorePaths.Add(expandedPath)
-        } else if !filepath.IsAbs(path) {
-            absolutePath, err := filepath.Abs(path)
-            if err != nil {
-                errorList.AddStringf("could not expand non-absolute path: %q", path)
-                continue
-            } 
-            ignorePaths.Add(absolutePath)
-        } else {
-            ignorePaths.Add(path)
-        }
-    }
+	for _, path := range cfg.Checks.IgnorePaths {
+		switch {
+		case path[0] == '~':
+			expandedPath, err := homedir.Expand(path)
+			if err != nil {
+				errorList.AddStringf("could not expand path: %q", path)
+				continue
+			}
+			ignorePaths.Add(expandedPath)
+		case !filepath.IsAbs(path):
+			absolutePath, err := filepath.Abs(path)
+			if err != nil {
+				errorList.AddStringf("could not expand non-absolute path: %q", path)
+				continue
+			}
+			ignorePaths.Add(absolutePath)
+		default:
+			ignorePaths.Add(path)
+		}
+	}
 	if err := errorList.ToError(); err != nil {
 		return nil, err
 	}
-    return ignorePaths.AsSortedSlice(func(i, j string) bool {
-        return i < j
-    }), nil
+	return ignorePaths.AsSortedSlice(func(i, j string) bool {
+		return i < j
+	}), nil
 }

--- a/pkg/configresolver/config_resolver.go
+++ b/pkg/configresolver/config_resolver.go
@@ -65,11 +65,11 @@ func GetIgnorePaths(cfg *config.Config) ([]string, error) {
 	errorList := errorhelpers.NewErrorList("check ignore paths")
 	ignorePaths := set.NewStringSet()
 	for _, path := range cfg.Checks.IgnorePaths {
-        res, err := getIgnorePath(path)
-        if err != nil {
-            errorList.AddError(err)
-            continue
-        }
+		res, err := getIgnorePath(path)
+		if err != nil {
+			errorList.AddError(err)
+			continue
+		}
 		ignorePaths.AddAll(res)
 	}
 

--- a/pkg/configresolver/config_resolver_test.go
+++ b/pkg/configresolver/config_resolver_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/stretchr/testify/assert"
-	c "golang.stackrox.io/kube-linter/pkg/config"
+	"golang.stackrox.io/kube-linter/pkg/config"
 )
 
 func TestIgnorePaths(t *testing.T) {
@@ -21,7 +21,7 @@ func TestIgnorePaths(t *testing.T) {
 	}
 
 	parent := filepath.Dir(wd)
-	cfg := new(c.Config)
+	c := new(config.Config)
 
 	var tests = []struct {
 		Path         []string
@@ -36,8 +36,8 @@ func TestIgnorePaths(t *testing.T) {
 	}
 
 	for _, e := range tests {
-		cfg.Checks.IgnorePaths = e.Path
-		paths, err := GetIgnorePaths(cfg)
+		c.Checks.IgnorePaths = e.Path
+		paths, err := GetIgnorePaths(c)
 
 		if e.ErrorExpeted {
 			assert.Error(t, err)

--- a/pkg/configresolver/config_resolver_test.go
+++ b/pkg/configresolver/config_resolver_test.go
@@ -1,0 +1,64 @@
+package configresolver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/stretchr/testify/assert"
+	"golang.stackrox.io/kube-linter/pkg/config"
+)
+
+var cfg *config.Config = new(config.Config)
+
+func TestHomeIgnorePath(t *testing.T) {
+	cfg.Checks.IgnorePaths = []string{"~/test"}
+
+	home, _ := homedir.Dir()
+	paths, err := GetIgnorePaths(cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, paths[0], home+"/test")
+}
+
+func TestHomeGlobIgnorePath(t *testing.T) {
+	cfg.Checks.IgnorePaths = []string{"~/*.yaml"}
+
+	home, _ := homedir.Dir()
+	paths, err := GetIgnorePaths(cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, paths[0], home+"/*.yaml")
+}
+
+func TestInvalidHomeIgnorePath(t *testing.T) {
+	cfg.Checks.IgnorePaths = []string{"~~/test"}
+
+	_, err := GetIgnorePaths(cfg)
+	assert.Error(t, err)
+}
+
+func TestRelativeIgnorePath(t *testing.T) {
+	cfg.Checks.IgnorePaths = []string{"../test"}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	parent := filepath.Dir(wd)
+	paths, err := GetIgnorePaths(cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, paths[0], parent+"/test")
+}
+
+func TestRelativeGlobIgnorePath(t *testing.T) {
+	cfg.Checks.IgnorePaths = []string{"../*.yaml"}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	parent := filepath.Dir(wd)
+	paths, err := GetIgnorePaths(cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, paths[0], parent+"/*.yaml")
+}

--- a/pkg/configresolver/config_resolver_test.go
+++ b/pkg/configresolver/config_resolver_test.go
@@ -42,7 +42,7 @@ func TestRelativeIgnorePath(t *testing.T) {
 
 	wd, err := os.Getwd()
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	parent := filepath.Dir(wd)
 	paths, err := GetIgnorePaths(cfg)
@@ -55,7 +55,7 @@ func TestRelativeGlobIgnorePath(t *testing.T) {
 
 	wd, err := os.Getwd()
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	parent := filepath.Dir(wd)
 	paths, err := GetIgnorePaths(cfg)

--- a/pkg/lintcontext/create_contexts.go
+++ b/pkg/lintcontext/create_contexts.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/bmatcuk/doublestar/v3"
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/pkg/errors"
 	"golang.stackrox.io/kube-linter/internal/set"
 	"helm.sh/helm/v3/pkg/chartutil"

--- a/pkg/lintcontext/create_contexts.go
+++ b/pkg/lintcontext/create_contexts.go
@@ -36,7 +36,7 @@ func CreateContexts(ignorePaths []string, filesOrDirs ...string) ([]LintContext,
 // CreateContextsWithOptions creates a context with additional Options
 func CreateContextsWithOptions(options Options, ignorePaths []string, filesOrDirs ...string) ([]LintContext, error) {
 	contextsByDir := make(map[string]*lintContextImpl)
-    fileOrDirsLoop:
+fileOrDirsLoop:
 	for _, fileOrDir := range filesOrDirs {
 		// Stdin
 		if fileOrDir == "-" {
@@ -51,11 +51,11 @@ func CreateContextsWithOptions(options Options, ignorePaths []string, filesOrDir
 			continue
 		}
 
-        for _, path := range ignorePaths {
-            if strings.HasPrefix(fileOrDir, path) {
-                continue fileOrDirsLoop
-            }
-        }
+		for _, path := range ignorePaths {
+			if strings.HasPrefix(fileOrDir, path) {
+				continue fileOrDirsLoop
+			}
+		}
 
 		err := filepath.Walk(fileOrDir, func(currentPath string, info os.FileInfo, walkErr error) error {
 			if walkErr != nil {

--- a/pkg/lintcontext/create_contexts.go
+++ b/pkg/lintcontext/create_contexts.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/bmatcuk/doublestar/v3"
 	"github.com/pkg/errors"
 	"golang.stackrox.io/kube-linter/internal/set"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -52,7 +53,10 @@ fileOrDirsLoop:
 		}
 
 		for _, path := range ignorePaths {
-			if strings.HasPrefix(fileOrDir, path) {
+			// Useing doublestar to enable **
+			// See https://github.com/golang/go/issues/11862
+			globMatch, _ := doublestar.PathMatch(path, fileOrDir)
+			if strings.HasPrefix(fileOrDir, path) || globMatch {
 				continue fileOrDirsLoop
 			}
 		}

--- a/pkg/lintcontext/create_contexts_test.go
+++ b/pkg/lintcontext/create_contexts_test.go
@@ -12,12 +12,13 @@ import (
 )
 
 const (
-	chartTarball    = "../../tests/testdata/mychart-0.1.0.tgz"
-	chartDirectory  = "../../tests/testdata/mychart"
-	renamedTarball  = "../../tests/testdata/my-renamed-chart-0.1.0.tgz"
-	renamedChartDir = "../../tests/testdata/my-renamed-chart"
-	mockIgnorePath  = "../../tests/testdata/"
-	mockPath        = "mock path"
+	chartTarball       = "../../tests/testdata/mychart-0.1.0.tgz"
+	chartDirectory     = "../../tests/testdata/mychart"
+	renamedTarball     = "../../tests/testdata/my-renamed-chart-0.1.0.tgz"
+	renamedChartDir    = "../../tests/testdata/my-renamed-chart"
+	mockIgnorePath     = "../../tests/testdata/"
+	mockGlobIgnorePath = "../../tests/**"
+	mockPath           = "mock path"
 )
 
 func TestCreateContextsObjectPaths(t *testing.T) {
@@ -27,16 +28,18 @@ func TestCreateContextsObjectPaths(t *testing.T) {
 		for _, absolute := range bools {
 			for _, rename := range bools {
 				for _, useFromArchiveFunction := range bools {
-					for _, useIgnorePaths := range bools {
-						// CreateContextsFromHelmArchive can only be used with tarballs
-						if useFromArchiveFunction && !useTarball {
-							continue
-						}
+					for _, useGlob := range bools {
+						for _, useIgnorePaths := range bools {
+							// CreateContextsFromHelmArchive can only be used with tarballs
+							if useFromArchiveFunction && !useTarball {
+								continue
+							}
 
-						testName := fmt.Sprintf("tarball %t, absolute path %t, rename %t, use from archive function %t, ignore paths: %t", useTarball, absolute, rename, useFromArchiveFunction, useIgnorePaths)
-						t.Run(testName, func(t *testing.T) {
-							createContextsAndVerifyPaths(t, useTarball, absolute, rename, useFromArchiveFunction, useIgnorePaths)
-						})
+							testName := fmt.Sprintf("tarball %t, absolute path %t, rename %t, use from archive function %t, ignore paths: %t (use glob: %t)", useTarball, absolute, rename, useFromArchiveFunction, useIgnorePaths, useGlob)
+							t.Run(testName, func(t *testing.T) {
+								createContextsAndVerifyPaths(t, useTarball, absolute, rename, useFromArchiveFunction, useIgnorePaths, useGlob)
+							})
+						}
 					}
 				}
 			}
@@ -44,7 +47,7 @@ func TestCreateContextsObjectPaths(t *testing.T) {
 	}
 }
 
-func createContextsAndVerifyPaths(t *testing.T, useTarball, useAbsolutePath, rename, useFromArchiveFunction, useIgnorePaths bool) {
+func createContextsAndVerifyPaths(t *testing.T, useTarball, useAbsolutePath, rename, useFromArchiveFunction, useIgnorePaths, useGlob bool) {
 	var err error
 
 	// Arrange
@@ -61,6 +64,10 @@ func createContextsAndVerifyPaths(t *testing.T, useTarball, useAbsolutePath, ren
 		defer func() {
 			assert.NoError(t, os.Rename(renamedPath, relativePath))
 		}()
+	}
+
+	if useGlob {
+		testIgnorePath = mockGlobIgnorePath
 	}
 
 	if useAbsolutePath {

--- a/pkg/lintcontext/create_contexts_test.go
+++ b/pkg/lintcontext/create_contexts_test.go
@@ -16,6 +16,7 @@ const (
 	chartDirectory  = "../../tests/testdata/mychart"
 	renamedTarball  = "../../tests/testdata/my-renamed-chart-0.1.0.tgz"
 	renamedChartDir = "../../tests/testdata/my-renamed-chart"
+	mockIgnorePath  = "../../tests/testdata/"
 	mockPath        = "mock path"
 )
 
@@ -26,22 +27,24 @@ func TestCreateContextsObjectPaths(t *testing.T) {
 		for _, absolute := range bools {
 			for _, rename := range bools {
 				for _, useFromArchiveFunction := range bools {
-					// CreateContextsFromHelmArchive can only be used with tarballs
-					if useFromArchiveFunction && !useTarball {
-						continue
-					}
+                    for _, useIgnorePaths := range bools {
+                        // CreateContextsFromHelmArchive can only be used with tarballs
+                        if useFromArchiveFunction && !useTarball {
+                            continue
+                        }
 
-					testName := fmt.Sprintf("tarball %t, absolute path %t, rename %t, use from archive function %t", useTarball, absolute, rename, useFromArchiveFunction)
-					t.Run(testName, func(t *testing.T) {
-						createContextsAndVerifyPaths(t, useTarball, absolute, rename, useFromArchiveFunction)
-					})
+                        testName := fmt.Sprintf("tarball %t, absolute path %t, rename %t, use from archive function %t, ignore paths: %t", useTarball, absolute, rename, useFromArchiveFunction, useIgnorePaths)
+                        t.Run(testName, func(t *testing.T) {
+                            createContextsAndVerifyPaths(t, useTarball, absolute, rename, useFromArchiveFunction, useIgnorePaths)
+                        })
+                    }
 				}
 			}
 		}
 	}
 }
 
-func createContextsAndVerifyPaths(t *testing.T, useTarball, useAbsolutePath, rename, useFromArchiveFunction bool) {
+func createContextsAndVerifyPaths(t *testing.T, useTarball, useAbsolutePath, rename, useFromArchiveFunction, useIgnorePaths bool) {
 	var err error
 
 	// Arrange
@@ -49,6 +52,8 @@ func createContextsAndVerifyPaths(t *testing.T, useTarball, useAbsolutePath, ren
 	renamedPath := map[bool]string{false: renamedChartDir, true: renamedTarball}[useTarball]
 
 	testPath := relativePath
+    testIgnorePath := mockIgnorePath
+    testIgnorePaths := make([]string, 0)
 
 	if rename {
 		testPath = renamedPath
@@ -61,7 +66,13 @@ func createContextsAndVerifyPaths(t *testing.T, useTarball, useAbsolutePath, ren
 	if useAbsolutePath {
 		testPath, err = filepath.Abs(testPath)
 		require.NoError(t, err)
+		testIgnorePath, err = filepath.Abs(testIgnorePath)
+		require.NoError(t, err)
 	}
+
+    if useIgnorePaths {
+        testIgnorePaths = append(testIgnorePaths, testIgnorePath)
+    }
 
 	// Act. The code actually tests either of functions: CreateContextsFromHelmArchive and CreateContexts
 	var lintCtxs []LintContext
@@ -76,7 +87,7 @@ func createContextsAndVerifyPaths(t *testing.T, useTarball, useAbsolutePath, ren
 
 		lintCtxs, err = CreateContextsFromHelmArchive(mockPath, file)
 	} else {
-		lintCtxs, err = CreateContexts(testPath)
+		lintCtxs, err = CreateContexts(testIgnorePaths, testPath)
 	}
 	require.NoError(t, err)
 
@@ -88,7 +99,17 @@ func createContextsAndVerifyPaths(t *testing.T, useTarball, useAbsolutePath, ren
 	if useFromArchiveFunction {
 		expectedPath = path.Join(mockPath, "mychart")
 	}
-	checkObjectPaths(t, verifyAndGetContext(t, lintCtxs).Objects(), expectedPath)
+
+    // IgnorePaths is only used for non helm cases
+    if useIgnorePaths && !useFromArchiveFunction {
+        checkEmptyLintContext(t, lintCtxs)
+    } else {
+        checkObjectPaths(t, verifyAndGetContext(t, lintCtxs).Objects(), expectedPath)
+    }
+}
+
+func checkEmptyLintContext(t *testing.T, lintCtxs []LintContext) {
+    assert.Len(t, lintCtxs, 0, "expecting no lint context")
 }
 
 func verifyAndGetContext(t *testing.T, lintCtxs []LintContext) LintContext {

--- a/pkg/lintcontext/create_contexts_test.go
+++ b/pkg/lintcontext/create_contexts_test.go
@@ -27,17 +27,17 @@ func TestCreateContextsObjectPaths(t *testing.T) {
 		for _, absolute := range bools {
 			for _, rename := range bools {
 				for _, useFromArchiveFunction := range bools {
-                    for _, useIgnorePaths := range bools {
-                        // CreateContextsFromHelmArchive can only be used with tarballs
-                        if useFromArchiveFunction && !useTarball {
-                            continue
-                        }
+					for _, useIgnorePaths := range bools {
+						// CreateContextsFromHelmArchive can only be used with tarballs
+						if useFromArchiveFunction && !useTarball {
+							continue
+						}
 
-                        testName := fmt.Sprintf("tarball %t, absolute path %t, rename %t, use from archive function %t, ignore paths: %t", useTarball, absolute, rename, useFromArchiveFunction, useIgnorePaths)
-                        t.Run(testName, func(t *testing.T) {
-                            createContextsAndVerifyPaths(t, useTarball, absolute, rename, useFromArchiveFunction, useIgnorePaths)
-                        })
-                    }
+						testName := fmt.Sprintf("tarball %t, absolute path %t, rename %t, use from archive function %t, ignore paths: %t", useTarball, absolute, rename, useFromArchiveFunction, useIgnorePaths)
+						t.Run(testName, func(t *testing.T) {
+							createContextsAndVerifyPaths(t, useTarball, absolute, rename, useFromArchiveFunction, useIgnorePaths)
+						})
+					}
 				}
 			}
 		}
@@ -52,8 +52,8 @@ func createContextsAndVerifyPaths(t *testing.T, useTarball, useAbsolutePath, ren
 	renamedPath := map[bool]string{false: renamedChartDir, true: renamedTarball}[useTarball]
 
 	testPath := relativePath
-    testIgnorePath := mockIgnorePath
-    testIgnorePaths := make([]string, 0)
+	testIgnorePath := mockIgnorePath
+	testIgnorePaths := make([]string, 0)
 
 	if rename {
 		testPath = renamedPath
@@ -70,9 +70,9 @@ func createContextsAndVerifyPaths(t *testing.T, useTarball, useAbsolutePath, ren
 		require.NoError(t, err)
 	}
 
-    if useIgnorePaths {
-        testIgnorePaths = append(testIgnorePaths, testIgnorePath)
-    }
+	if useIgnorePaths {
+		testIgnorePaths = append(testIgnorePaths, testIgnorePath)
+	}
 
 	// Act. The code actually tests either of functions: CreateContextsFromHelmArchive and CreateContexts
 	var lintCtxs []LintContext
@@ -100,16 +100,16 @@ func createContextsAndVerifyPaths(t *testing.T, useTarball, useAbsolutePath, ren
 		expectedPath = path.Join(mockPath, "mychart")
 	}
 
-    // IgnorePaths is only used for non helm cases
-    if useIgnorePaths && !useFromArchiveFunction {
-        checkEmptyLintContext(t, lintCtxs)
-    } else {
-        checkObjectPaths(t, verifyAndGetContext(t, lintCtxs).Objects(), expectedPath)
-    }
+	// IgnorePaths is only used for non helm cases
+	if useIgnorePaths && !useFromArchiveFunction {
+		checkEmptyLintContext(t, lintCtxs)
+	} else {
+		checkObjectPaths(t, verifyAndGetContext(t, lintCtxs).Objects(), expectedPath)
+	}
 }
 
 func checkEmptyLintContext(t *testing.T, lintCtxs []LintContext) {
-    assert.Len(t, lintCtxs, 0, "expecting no lint context")
+	assert.Len(t, lintCtxs, 0, "expecting no lint context")
 }
 
 func verifyAndGetContext(t *testing.T, lintCtxs []LintContext) LintContext {


### PR DESCRIPTION
## Problem

We would like to exclude some directories from being checked while using the tool (fix #127)

## Solution

- Add `check.ignorePaths` configuration option that supports relative, homedir, and glob paths (didn't go with `excludePaths` since it might be confusing with the existing `exclude` option)

~This is a WIP~. Let me know if you would like to see more tests or have suggestions!