### PR TITLE
Set permissions to binaries before uploading them.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -170,7 +170,7 @@ jobs:
           name: bin
 
       - name: Set permissions to file
-        run:  chmod +x linux/kube-linter
+        run: chmod +x linux/kube-linter
 
       - name: Move binary
         run:  mv linux/kube-linter image/bin
@@ -296,6 +296,12 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: bin
+
+      - name: Set permissions to files
+        run: |
+          chmod +x linux/kube-linter
+          chmod +x darwin/kube-linter
+
       - name: create archives
         run: |
           for os in darwin linux windows; do
@@ -319,6 +325,7 @@ jobs:
           for f in *.{gz,zip}; do \
             cosign sign-blob --key cosign.key --output-file "${f}.sig" "${f}"; \
           done
+
       - uses: release-drafter/release-drafter@v5
         id: release_drafter
         env:


### PR DESCRIPTION
# Description

There is an issue currently with the release of kube-linter, specifically the permissions on the binaries.

When uploading them, they are not set to be executable. However, the kube-linter-github-action expects them to be.

While we could fix the action to ensure the binary is executable as well, the permission was set in the past, so we should ensure this is the case once more.