### PR TITLE
Skip failing anti-affinity rules if at least one valid rule is found.

### DIFF
--- a/pkg/templates/antiaffinity/template.go
+++ b/pkg/templates/antiaffinity/template.go
@@ -72,6 +72,15 @@ func init() {
 				var foundIssues []diagnostic.Diagnostic
 				preferredAffinity := affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
 				requiredAffinity := affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+				// Short-circuit if affinity rule is specified but both preferred and required are empty.
+				if len(preferredAffinity) == 0 && len(requiredAffinity) == 0 {
+					return []diagnostic.Diagnostic{
+						{Message: fmt.Sprintf("object has %d %s but does not specify preferred or required "+
+							"inter pod anti-affinity during scheduling",
+							replicas, stringutils.Ternary(replicas > 1, "replicas", "replica"))},
+					}
+				}
+
 				for _, preferred := range preferredAffinity {
 					err := validateAffinityTermMatchesAgainstNodes(preferred.PodAffinityTerm,
 						podTemplateSpec.Namespace, podTemplateSpec.Labels, topologyKeyMatcher)

--- a/pkg/templates/antiaffinity/template.go
+++ b/pkg/templates/antiaffinity/template.go
@@ -75,20 +75,22 @@ func init() {
 				for _, preferred := range preferredAffinity {
 					err := validateAffinityTermMatchesAgainstNodes(preferred.PodAffinityTerm,
 						podTemplateSpec.Namespace, podTemplateSpec.Labels, topologyKeyMatcher)
-					if err != nil {
-						foundIssues = append(foundIssues, diagnostic.Diagnostic{
-							Message: err.Error(),
-						})
+					if err == nil {
+						return nil
 					}
+					foundIssues = append(foundIssues, diagnostic.Diagnostic{
+						Message: err.Error(),
+					})
 				}
 				for _, required := range requiredAffinity {
 					err := validateAffinityTermMatchesAgainstNodes(required, podTemplateSpec.Namespace,
 						podTemplateSpec.Labels, topologyKeyMatcher)
-					if err != nil {
-						foundIssues = append(foundIssues, diagnostic.Diagnostic{
-							Message: err.Error(),
-						})
+					if err == nil {
+						return nil
 					}
+					foundIssues = append(foundIssues, diagnostic.Diagnostic{
+						Message: err.Error(),
+					})
 				}
 				return foundIssues
 			}, nil


### PR DESCRIPTION
# Description

When adding [more verbose errors to no-anti-affinity check](https://github.com/stackrox/kube-linter/pull/318), we remove the short-circuiting on the first valid anti-affinity rule.
However, we should short-circuit on the first anti-affinity rule, as this is the expected behavior of the check.

Fixes #369 