### PR TITLE
Added t.Run() to use test name in unit test

### DIFF
--- a/pkg/command/common/template_test.go
+++ b/pkg/command/common/template_test.go
@@ -26,12 +26,14 @@ func TestMarkdownFunctions(t *testing.T) {
 	}
 
 	for _, tt := range templateTests {
-		tpl := common.MustInstantiateMarkdownTemplate(tt.in, nil)
+		t.Run(tt.name, func(t *testing.T) {
+			tpl := common.MustInstantiateMarkdownTemplate(tt.in, nil)
 
-		var b bytes.Buffer
+			var b bytes.Buffer
 
-		require.NoError(t, tpl.Execute(&b, tt.data))
+			require.NoError(t, tpl.Execute(&b, tt.data))
 
-		assert.Equal(t, tt.out, b.String())
+			assert.Equal(t, tt.out, b.String())
+		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: Ankit Kurmi <ankitkurmi152@gmail.com>

## Description

Added `t.Run()` to use test name for the unit test present in `pkg/common/command/template_test.go`.