### PR TITLE
fix: Update object kinds for lint templates

### DIFF
--- a/docs/generated/templates.md
+++ b/docs/generated/templates.md
@@ -108,7 +108,7 @@ KubeLinter supports the following templates:
 
 **Description**: Flag HorizontalPodAutoscalers that target a resource that does not exist
 
-**Supported Objects**: HorizontalPodAutoscaler
+**Supported Objects**: HorizontalPodAutoscaler,DeploymentLike
 
 
 ## Dangling NetworkPolicies
@@ -117,7 +117,7 @@ KubeLinter supports the following templates:
 
 **Description**: Flag NetworkPolicies which do not match any application
 
-**Supported Objects**: DeploymentLike
+**Supported Objects**: DeploymentLike,NetworkPolicy
 
 
 ## Dangling NetworkPolicyPeer PodSelector
@@ -126,7 +126,7 @@ KubeLinter supports the following templates:
 
 **Description**: Flag NetworkPolicyPeer in Ingress/Egress rules which their podselector do not match any application. Applied to peers consisting with podSelectors only.
 
-**Supported Objects**: DeploymentLike
+**Supported Objects**: DeploymentLike,NetworkPolicy
 
 
 ## Dangling Services
@@ -135,7 +135,7 @@ KubeLinter supports the following templates:
 
 **Description**: Flag services which do not match any application
 
-**Supported Objects**: DeploymentLike
+**Supported Objects**: DeploymentLike,Service
 
 
 ## Deprecated Service Account Field
@@ -485,7 +485,7 @@ KubeLinter supports the following templates:
 
 **Description**: Flag cases where a pod references a non-existent service account
 
-**Supported Objects**: DeploymentLike
+**Supported Objects**: DeploymentLike,ServiceAccount
 
 
 ## Non Isolated Pods
@@ -494,7 +494,7 @@ KubeLinter supports the following templates:
 
 **Description**: Flag Pod that is not selected by any networkPolicy
 
-**Supported Objects**: NetworkPolicy
+**Supported Objects**: NetworkPolicy,DeploymentLike
 
 
 ## Ports
@@ -749,7 +749,7 @@ KubeLinter supports the following templates:
 
 **Description**: Flag resources with no namespace specified or using default namespace
 
-**Supported Objects**: DeploymentLike,Service
+**Supported Objects**: DeploymentLike,HorizontalPodAutoscaler,NetworkPolicy,Role,RoleBinding,Service,ServiceAccount
 
 
 ## Verify container capabilities

--- a/pkg/lintcontext/mocks/horizontalpodautoscaler.go
+++ b/pkg/lintcontext/mocks/horizontalpodautoscaler.go
@@ -59,28 +59,28 @@ func (l *MockLintContext) AddMockHorizontalPodAutoscaler(t *testing.T, name, ver
 	}
 }
 
-//ModifyHorizontalPodAutoscalerV2Beta1 modifies a given HorizontalPodAutoscaler in the context via the passed function.
+// ModifyHorizontalPodAutoscalerV2Beta1 modifies a given HorizontalPodAutoscaler in the context via the passed function.
 func (l *MockLintContext) ModifyHorizontalPodAutoscalerV2Beta1(t *testing.T, name string, f func(hpa *autoscalingV2Beta1.HorizontalPodAutoscaler)) {
 	r, ok := l.objects[name].(*autoscalingV2Beta1.HorizontalPodAutoscaler)
 	require.True(t, ok)
 	f(r)
 }
 
-//ModifyHorizontalPodAutoscalerV2Beta2 modifies a given HorizontalPodAutoscaler in the context via the passed function.
+// ModifyHorizontalPodAutoscalerV2Beta2 modifies a given HorizontalPodAutoscaler in the context via the passed function.
 func (l *MockLintContext) ModifyHorizontalPodAutoscalerV2Beta2(t *testing.T, name string, f func(hpa *autoscalingV2Beta2.HorizontalPodAutoscaler)) {
 	r, ok := l.objects[name].(*autoscalingV2Beta2.HorizontalPodAutoscaler)
 	require.True(t, ok)
 	f(r)
 }
 
-//ModifyHorizontalPodAutoscalerV2 modifies a given HorizontalPodAutoscaler in the context via the passed function.
+// ModifyHorizontalPodAutoscalerV2 modifies a given HorizontalPodAutoscaler in the context via the passed function.
 func (l *MockLintContext) ModifyHorizontalPodAutoscalerV2(t *testing.T, name string, f func(hpa *autoscalingV2.HorizontalPodAutoscaler)) {
 	r, ok := l.objects[name].(*autoscalingV2.HorizontalPodAutoscaler)
 	require.True(t, ok)
 	f(r)
 }
 
-//ModifyHorizontalPodAutoscalerV1 modifies a given HorizontalPodAutoscaler in the context via the passed function.
+// ModifyHorizontalPodAutoscalerV1 modifies a given HorizontalPodAutoscaler in the context via the passed function.
 func (l *MockLintContext) ModifyHorizontalPodAutoscalerV1(t *testing.T, name string, f func(hpa *autoscalingV1.HorizontalPodAutoscaler)) {
 	r, ok := l.objects[name].(*autoscalingV1.HorizontalPodAutoscaler)
 	require.True(t, ok)

--- a/pkg/lintcontext/mocks/networkpolicy.go
+++ b/pkg/lintcontext/mocks/networkpolicy.go
@@ -22,7 +22,7 @@ func (l *MockLintContext) AddMockNetworkPolicy(t *testing.T, name string) {
 	}
 }
 
-//ModifyNetworkPolicy modifies a given networkpolicy in the context via the passed function.
+// ModifyNetworkPolicy modifies a given networkpolicy in the context via the passed function.
 func (l *MockLintContext) ModifyNetworkPolicy(t *testing.T, name string, f func(networkpolicy *networkingV1.NetworkPolicy)) {
 	r, ok := l.objects[name].(*networkingV1.NetworkPolicy)
 	require.True(t, ok)

--- a/pkg/objectkinds/networkpolicy.go
+++ b/pkg/objectkinds/networkpolicy.go
@@ -20,7 +20,7 @@ func init() {
 	}))
 }
 
-//GetNetworkPolicyAPIVersion returns networkpolicy's apiversion
+// GetNetworkPolicyAPIVersion returns networkpolicy's apiversion
 func GetNetworkPolicyAPIVersion() string {
 	return networkpolicyGVK.GroupVersion().String()
 }

--- a/pkg/templates/danglinghpa/template.go
+++ b/pkg/templates/danglinghpa/template.go
@@ -24,7 +24,7 @@ func init() {
 		Key:         templateKey,
 		Description: "Flag HorizontalPodAutoscalers that target a resource that does not exist",
 		SupportedObjectKinds: config.ObjectKindsDesc{
-			ObjectKinds: []string{objectkinds.HorizontalPodAutoscaler},
+			ObjectKinds: []string{objectkinds.HorizontalPodAutoscaler, objectkinds.DeploymentLike},
 		},
 		Parameters:             params.ParamDescs,
 		ParseAndValidateParams: params.ParseAndValidate,

--- a/pkg/templates/danglingnetworkpolicy/template.go
+++ b/pkg/templates/danglingnetworkpolicy/template.go
@@ -27,7 +27,7 @@ func init() {
 		Key:         "dangling-networkpolicy",
 		Description: "Flag NetworkPolicies which do not match any application",
 		SupportedObjectKinds: config.ObjectKindsDesc{
-			ObjectKinds: []string{objectkinds.DeploymentLike},
+			ObjectKinds: []string{objectkinds.DeploymentLike, objectkinds.NetworkPolicy},
 		},
 		Parameters:             params.ParamDescs,
 		ParseAndValidateParams: params.ParseAndValidate,

--- a/pkg/templates/danglingnetworkpolicypeer/template.go
+++ b/pkg/templates/danglingnetworkpolicypeer/template.go
@@ -27,7 +27,7 @@ func init() {
 		Key:         templateKey,
 		Description: "Flag NetworkPolicyPeer in Ingress/Egress rules which their podselector do not match any application. Applied to peers consisting with podSelectors only.",
 		SupportedObjectKinds: config.ObjectKindsDesc{
-			ObjectKinds: []string{objectkinds.DeploymentLike},
+			ObjectKinds: []string{objectkinds.DeploymentLike, objectkinds.NetworkPolicy},
 		},
 		Parameters:             params.ParamDescs,
 		ParseAndValidateParams: params.ParseAndValidate,

--- a/pkg/templates/danglingservice/template.go
+++ b/pkg/templates/danglingservice/template.go
@@ -22,7 +22,7 @@ func init() {
 		Key:         "dangling-service",
 		Description: "Flag services which do not match any application",
 		SupportedObjectKinds: config.ObjectKindsDesc{
-			ObjectKinds: []string{objectkinds.DeploymentLike},
+			ObjectKinds: []string{objectkinds.DeploymentLike, objectkinds.Service},
 		},
 		Parameters:             params.ParamDescs,
 		ParseAndValidateParams: params.ParseAndValidate,

--- a/pkg/templates/namespace/template.go
+++ b/pkg/templates/namespace/template.go
@@ -19,7 +19,15 @@ func init() {
 		Key:         "use-namespace",
 		Description: "Flag resources with no namespace specified or using default namespace",
 		SupportedObjectKinds: config.ObjectKindsDesc{
-			ObjectKinds: []string{objectkinds.DeploymentLike, objectkinds.Service},
+			ObjectKinds: []string{
+				objectkinds.DeploymentLike,
+				objectkinds.HorizontalPodAutoscaler,
+				objectkinds.NetworkPolicy,
+				objectkinds.Role,
+				objectkinds.RoleBinding,
+				objectkinds.Service,
+				objectkinds.ServiceAccount,
+			},
 		},
 		Parameters:             params.ParamDescs,
 		ParseAndValidateParams: params.ParseAndValidate,

--- a/pkg/templates/nonexistentserviceaccount/template.go
+++ b/pkg/templates/nonexistentserviceaccount/template.go
@@ -26,7 +26,7 @@ func init() {
 		Key:         "non-existent-service-account",
 		Description: "Flag cases where a pod references a non-existent service account",
 		SupportedObjectKinds: config.ObjectKindsDesc{
-			ObjectKinds: []string{objectkinds.DeploymentLike},
+			ObjectKinds: []string{objectkinds.DeploymentLike, objectkinds.ServiceAccount},
 		},
 		Parameters:             params.ParamDescs,
 		ParseAndValidateParams: params.ParseAndValidate,

--- a/pkg/templates/nonisolatedpod/template.go
+++ b/pkg/templates/nonisolatedpod/template.go
@@ -26,7 +26,7 @@ func init() {
 		Key:         templateKey,
 		Description: "Flag Pod that is not selected by any networkPolicy",
 		SupportedObjectKinds: config.ObjectKindsDesc{
-			ObjectKinds: []string{objectkinds.NetworkPolicy},
+			ObjectKinds: []string{objectkinds.NetworkPolicy, objectkinds.DeploymentLike},
 		},
 		Parameters:             params.ParamDescs,
 		ParseAndValidateParams: params.ParseAndValidate,


### PR DESCRIPTION
This expands the object kinds for a number of lint checks, to include resources that are accessed by the lint check function. I have gone through all of the templates and these are the only ones I found where the objects accessed in the function do not match the ObjectKinds.

This means that the ObjectKinds field more accurately reflects the reality of what resources a lint check expects to be able to access. Any unsupported objects are still filtered by the checks, so this does not effect the function of the checks.

I believe clarifying the intent of these templates is a good thing in-and-of itself, but there are also other usecases, especially when running kube-linter in-cluster.

I hope this is trivial enough, but happy to raise an issue or discuss further if that helps. 