### PR TITLE
feat: Add ephemeral containers to PodSpec.AllContainers()

### DIFF
--- a/pkg/extract/customtypes/pod_spec.go
+++ b/pkg/extract/customtypes/pod_spec.go
@@ -13,11 +13,18 @@ type PodSpec struct {
 	v1.PodSpec
 }
 
-// AllContainers returns a list of all containers in the Pod, both Init and Regular
+// AllContainers returns a list of all containers in the Pod, including Init, Regular, and Ephemeral
 func (p *PodSpec) AllContainers() []v1.Container {
 	allContainers := make([]v1.Container, 0, len(p.PodSpec.InitContainers)+len(p.PodSpec.Containers))
 	allContainers = append(allContainers, p.PodSpec.InitContainers...)
 	allContainers = append(allContainers, p.PodSpec.Containers...)
+
+	// Per KEP277, EphemeralContainerCommon is required by the compiler to be field-for-field matching with v1.Container
+	// https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/277-ephemeral-containers/README.md
+	for _, e := range p.PodSpec.EphemeralContainers {
+		allContainers = append(allContainers, v1.Container(e.EphemeralContainerCommon))
+	}
+
 	return allContainers
 }
 
@@ -29,4 +36,9 @@ func (p *PodSpec) NonInitContainers() []v1.Container {
 // InitContainers returns a list of all init containers in the Pod
 func (p *PodSpec) InitContainers() []v1.Container {
 	return p.PodSpec.InitContainers
+}
+
+// EphemeralContainers returns a list of all ephemeral containers in the Pod
+func (p *PodSpec) EphemeralContainers() []v1.EphemeralContainer {
+	return p.PodSpec.EphemeralContainers
 }

--- a/pkg/lintcontext/mocks/horizontalpodautoscaler.go
+++ b/pkg/lintcontext/mocks/horizontalpodautoscaler.go
@@ -59,28 +59,28 @@ func (l *MockLintContext) AddMockHorizontalPodAutoscaler(t *testing.T, name, ver
 	}
 }
 
-//ModifyHorizontalPodAutoscalerV2Beta1 modifies a given HorizontalPodAutoscaler in the context via the passed function.
+// ModifyHorizontalPodAutoscalerV2Beta1 modifies a given HorizontalPodAutoscaler in the context via the passed function.
 func (l *MockLintContext) ModifyHorizontalPodAutoscalerV2Beta1(t *testing.T, name string, f func(hpa *autoscalingV2Beta1.HorizontalPodAutoscaler)) {
 	r, ok := l.objects[name].(*autoscalingV2Beta1.HorizontalPodAutoscaler)
 	require.True(t, ok)
 	f(r)
 }
 
-//ModifyHorizontalPodAutoscalerV2Beta2 modifies a given HorizontalPodAutoscaler in the context via the passed function.
+// ModifyHorizontalPodAutoscalerV2Beta2 modifies a given HorizontalPodAutoscaler in the context via the passed function.
 func (l *MockLintContext) ModifyHorizontalPodAutoscalerV2Beta2(t *testing.T, name string, f func(hpa *autoscalingV2Beta2.HorizontalPodAutoscaler)) {
 	r, ok := l.objects[name].(*autoscalingV2Beta2.HorizontalPodAutoscaler)
 	require.True(t, ok)
 	f(r)
 }
 
-//ModifyHorizontalPodAutoscalerV2 modifies a given HorizontalPodAutoscaler in the context via the passed function.
+// ModifyHorizontalPodAutoscalerV2 modifies a given HorizontalPodAutoscaler in the context via the passed function.
 func (l *MockLintContext) ModifyHorizontalPodAutoscalerV2(t *testing.T, name string, f func(hpa *autoscalingV2.HorizontalPodAutoscaler)) {
 	r, ok := l.objects[name].(*autoscalingV2.HorizontalPodAutoscaler)
 	require.True(t, ok)
 	f(r)
 }
 
-//ModifyHorizontalPodAutoscalerV1 modifies a given HorizontalPodAutoscaler in the context via the passed function.
+// ModifyHorizontalPodAutoscalerV1 modifies a given HorizontalPodAutoscaler in the context via the passed function.
 func (l *MockLintContext) ModifyHorizontalPodAutoscalerV1(t *testing.T, name string, f func(hpa *autoscalingV1.HorizontalPodAutoscaler)) {
 	r, ok := l.objects[name].(*autoscalingV1.HorizontalPodAutoscaler)
 	require.True(t, ok)

--- a/pkg/lintcontext/mocks/networkpolicy.go
+++ b/pkg/lintcontext/mocks/networkpolicy.go
@@ -22,7 +22,7 @@ func (l *MockLintContext) AddMockNetworkPolicy(t *testing.T, name string) {
 	}
 }
 
-//ModifyNetworkPolicy modifies a given networkpolicy in the context via the passed function.
+// ModifyNetworkPolicy modifies a given networkpolicy in the context via the passed function.
 func (l *MockLintContext) ModifyNetworkPolicy(t *testing.T, name string, f func(networkpolicy *networkingV1.NetworkPolicy)) {
 	r, ok := l.objects[name].(*networkingV1.NetworkPolicy)
 	require.True(t, ok)

--- a/pkg/objectkinds/networkpolicy.go
+++ b/pkg/objectkinds/networkpolicy.go
@@ -20,7 +20,7 @@ func init() {
 	}))
 }
 
-//GetNetworkPolicyAPIVersion returns networkpolicy's apiversion
+// GetNetworkPolicyAPIVersion returns networkpolicy's apiversion
 func GetNetworkPolicyAPIVersion() string {
 	return networkpolicyGVK.GroupVersion().String()
 }


### PR DESCRIPTION
EphemeralContainers were promoted to beta in 1.23, so we should add support for them.

This also includes a couple of small comment fixes from running `make lint` locally.