### PR TITLE
antiaffinity check with namespaces: selector

### DIFF
--- a/e2etests/bats-tests.sh
+++ b/e2etests/bats-tests.sh
@@ -416,11 +416,13 @@ get_value_from() {
 
   message1=$(get_value_from "${lines[0]}" '.Reports[0].Object.K8sObject.GroupVersionKind.Kind + ": " + .Reports[0].Diagnostic.Message')
   message2=$(get_value_from "${lines[0]}" '.Reports[1].Object.K8sObject.GroupVersionKind.Kind + ": " +.Reports[1].Diagnostic.Message')
+  message3=$(get_value_from "${lines[0]}" '.Reports[2].Object.K8sObject.GroupVersionKind.Kind + ": " +.Reports[2].Diagnostic.Message')
   count=$(get_value_from "${lines[0]}" '.Reports | length')
 
   [[ "${message1}" == "Deployment: object has 3 replicas but does not specify inter pod anti-affinity" ]]
   [[ "${message2}" == "DeploymentConfig: object has 3 replicas but does not specify inter pod anti-affinity" ]]
-  [[ "${count}" == "2" ]]
+  [[ "${message3}" == "Deployment: pod's namespace \"foo\" not found in anti-affinity's namespaces [bar]" ]]
+  [[ "${count}" == "3" ]]
 }
 
 @test "no-extensions-v1beta" {

--- a/pkg/templates/antiaffinity/template.go
+++ b/pkg/templates/antiaffinity/template.go
@@ -61,6 +61,7 @@ func init() {
 				if !hasPods {
 					return nil
 				}
+				namespace := object.K8sObject.GetNamespace()
 				affinity := podTemplateSpec.Spec.Affinity
 				// Short-circuit if no affinity rule is specified within the pod spec.
 				if affinity == nil || affinity.PodAntiAffinity == nil {
@@ -83,7 +84,7 @@ func init() {
 
 				for _, preferred := range preferredAffinity {
 					err := validateAffinityTermMatchesAgainstNodes(preferred.PodAffinityTerm,
-						podTemplateSpec.Namespace, podTemplateSpec.Labels, topologyKeyMatcher)
+						namespace, podTemplateSpec.Labels, topologyKeyMatcher)
 					if err == nil {
 						return nil
 					}
@@ -92,7 +93,7 @@ func init() {
 					})
 				}
 				for _, required := range requiredAffinity {
-					err := validateAffinityTermMatchesAgainstNodes(required, podTemplateSpec.Namespace,
+					err := validateAffinityTermMatchesAgainstNodes(required, namespace,
 						podTemplateSpec.Labels, topologyKeyMatcher)
 					if err == nil {
 						return nil

--- a/tests/checks/no-anti-affinity.yml
+++ b/tests/checks/no-anti-affinity.yml
@@ -71,3 +71,91 @@ spec:
     spec:
       containers:
       - name: app
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire-namespaced-without-namespaces-selector
+  namespace: foo
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dont-fire
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dont-fire
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                      - dont-fire
+              topologyKey: "kubernetes.io/hostname"
+      containers:
+        - name: app
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dont-fire-namespaced-with-namespaces-selector
+  namespace: foo
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dont-fire
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dont-fire
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                      - dont-fire
+              topologyKey: "kubernetes.io/hostname"
+              namespaces:
+              - foo
+      containers:
+        - name: app
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fire-namespaced-with-namespaces-selector-not-matching
+  namespace: foo
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: fire
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: fire
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                      - fire
+              topologyKey: "kubernetes.io/hostname"
+              namespaces:
+              - bar
+      containers:
+        - name: app


### PR DESCRIPTION
antiaffinity check uses `.spec.template.metadata.namespace` instead of the workload's `.metadata.namespace`.