### PR TITLE
fix: pre-commit-hooks and docs

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,14 +1,14 @@
 - id: kube-linter
   name: KubeLinter
   description: This hook installs (using Go) and runs the KubeLinter utility to lint Helm charts and Kubernetes YAML files.
-  entry: kube-linter
+  entry: kube-linter lint 
   language: golang
   types: [yaml]
 
 - id: kube-linter-system
   name: KubeLinter System
   description: This hook runs the KubeLinter utility that exists already on the system to lint Helm charts and Kubernetes YAML files.
-  entry: kube-linter
+  entry: kube-linter lint 
   language: system
   types: [yaml]
 
@@ -17,4 +17,4 @@
   description: This hook runs kube-linter using the project's official docker image
   language: docker_image
   types: [yaml]
-  entry: stackrox/kube-linter:0.2.6
+  entry: stackrox/kube-linter:0.2.6 lint 

--- a/docs/using-kubelinter.md
+++ b/docs/using-kubelinter.md
@@ -37,20 +37,15 @@ kube-linter lint /path/to/directory/containing/Chart.yaml-file/
 
 If you are using the [pre-commit framework](https://pre-commit.com/) for
 managing Git pre-commit hooks, you can install and use KubeLinter as a
-pre-commit hook. To do this:
+pre-commit hook. To do this, add the following to your `.pre-commit-config.yaml`:
 
-1. Download the [`.pre-commit-hooks.yaml`](https://raw.githubusercontent.com/stackrox/kube-linter/main/.pre-commit-hooks.yaml)
-   file in the Git repository in which you want to install the KubeLinter
-   pre-commit hooks:
-   ```bash
-   curl -O https://raw.githubusercontent.com/stackrox/kube-linter/main/.pre-commit-hooks.yaml
-   ```
-1. Run the `pre-commit install` command:
-   ```bash
-   pre-commit install
-   ```
-1. After installation, the KubeLinter pre-commit hooks run whenever you run the
-   `git commit` command.
+```yaml
+  - repo: https://github.com/stackrox/kube-linter
+    rev: 0.6.0 # kube-linter version 
+    hooks:
+        # You can change this to kube-linter-system or kube-linter-docker
+      - id: kube-linter
+```
 
 The [`.pre-commit-hooks.yaml`](https://raw.githubusercontent.com/stackrox/kube-linter/main/.pre-commit-hooks.yaml)
 includes the following pre-commit hooks:


### PR DESCRIPTION
Hi
This PR implement this issue #222 
 - Fix pre-commit-hooks to work with canonical pre-commit 
 - Also update the documentation to reflect the changes

You can now add the hook by adding the following to your `.pre-commit-config.yaml`:

```yaml
  - repo: https://github.com/stackrox/kube-linter
    rev: 0.6.0 # kube-linter version 
    hooks:
        # You can change this to kube-linter-system or kube-linter-docker
      - id: kube-linter
```

