### PR TITLE
fix: add `v` prefix to release-drafter's tag template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
 name-template: "v$NEXT_PATCH_VERSION 🌈"
-tag-template: "$NEXT_PATCH_VERSION"
+tag-template: "v$NEXT_PATCH_VERSION"
 categories:
   - title: "🚀 Features"
     labels:


### PR DESCRIPTION
In order to make tags created by the release-drafter compatible with Go modules, tags have to begin with `v` prefix.

It should fix #494.