### PR TITLE
Fix go install for newer golangs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Visit https://docs.kubelinter.io for detailed documentation on installing, using
 To install using [Go](https://golang.org/), run the following command:
 
 ```bash
-GO111MODULE=on go install golang.stackrox.io/kube-linter/cmd/kube-linter
+go install golang.stackrox.io/kube-linter/cmd/kube-linter@latest
 ```
 Otherwise, download the latest binary from [Releases](https://github.com/stackrox/kube-linter/releases) and add it to your
 PATH.


### PR DESCRIPTION
I was greeted with this error:
```
 ▶ GO111MODULE=on go install golang.stackrox.io/kube-linter/cmd/kube-linter
go: 'go install' requires a version when current directory is not in a module
        Try 'go install golang.stackrox.io/kube-linter/cmd/kube-linter@latest' to install the latest version
```
also setting ``GO11MODULE`` shouldn't be required since a while now.