### PR TITLE
fix/linting for percentage based values

### DIFF
--- a/pkg/templates/pdbmaxunavailable/template_test.go
+++ b/pkg/templates/pdbmaxunavailable/template_test.go
@@ -7,7 +7,7 @@ import (
 	"golang.stackrox.io/kube-linter/pkg/diagnostic"
 	"golang.stackrox.io/kube-linter/pkg/lintcontext/mocks"
 	"golang.stackrox.io/kube-linter/pkg/templates"
-	v1 "k8s.io/api/policy/v1"
+	pdbv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"golang.stackrox.io/kube-linter/pkg/templates/pdbmaxunavailable/internal/params"
@@ -28,40 +28,72 @@ func (p *PDBTestSuite) SetupTest() {
 	p.ctx = mocks.NewMockContext()
 }
 
-func (p *PDBTestSuite) TestPDBMaxUnavailableZero() {
-
-	p.ctx.AddMockPodDisruptionBudget(p.T(), "test-pdb")
-	p.ctx.ModifyPodDisruptionBudget(p.T(), "test-pdb", func(pdb *v1.PodDisruptionBudget) {
-		pdb.Spec.MaxUnavailable = &intstr.IntOrString{IntVal: 0}
-	})
-
-	p.Validate(p.ctx, []templates.TestCase{
-		{
-			Param: params.Params{},
-			Diagnostics: map[string][]diagnostic.Diagnostic{
-				"test-pdb": {
-					{Message: "MaxUnavailable is set to 0"},
-				},
-			},
-			ExpectInstantiationError: false,
-		},
-	})
+func toPointer(v intstr.IntOrString) *intstr.IntOrString {
+	return &v
 }
 
-func (p *PDBTestSuite) TestPDBMaxUnavailableOne() {
-
-	p.ctx.AddMockPodDisruptionBudget(p.T(), "test-pdb")
-	p.ctx.ModifyPodDisruptionBudget(p.T(), "test-pdb", func(pdb *v1.PodDisruptionBudget) {
-		pdb.Spec.MaxUnavailable = &intstr.IntOrString{IntVal: 1}
-	})
-
-	p.Validate(p.ctx, []templates.TestCase{
+func (p *PDBTestSuite) TestPDB() {
+	testCases := []struct {
+		Name           string
+		Message        string
+		MaxUnavailable *intstr.IntOrString
+	}{
 		{
-			Param: params.Params{},
-			Diagnostics: map[string][]diagnostic.Diagnostic{
-				"test-pdb": {},
-			},
-			ExpectInstantiationError: false,
+			Name:           "As Not Defined (nil)",
+			MaxUnavailable: nil,
 		},
-	})
+		{
+			Name:           "Invalid Value As String",
+			Message:        "maxUnavailable has invalid value [invalid-value]",
+			MaxUnavailable: toPointer(intstr.FromString("invalid-value")),
+		},
+		{
+			Name:           "Zero As Integer",
+			Message:        "MaxUnavailable is set to 0",
+			MaxUnavailable: toPointer(intstr.FromInt(0)),
+		},
+		{
+			Name:           "Zero As String Percentage",
+			Message:        "MaxUnavailable is set to 0",
+			MaxUnavailable: toPointer(intstr.FromString("0%")),
+		},
+		{
+			Name:           "Zero As String",
+			Message:        "maxUnavailable has invalid value [0]",
+			MaxUnavailable: toPointer(intstr.FromString("0")),
+		},
+		{
+			Name:           "One As Integer",
+			MaxUnavailable: toPointer(intstr.FromInt(1)),
+		},
+		{
+			Name:           "One As String Percentage",
+			MaxUnavailable: toPointer(intstr.FromString("1%")),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		p.Run(tc.Name, func() {
+			p.ctx.AddMockPodDisruptionBudget(p.T(), "test-pdb")
+			p.ctx.ModifyPodDisruptionBudget(p.T(), "test-pdb", func(pdb *pdbv1.PodDisruptionBudget) {
+				pdb.Spec.MaxUnavailable = tc.MaxUnavailable
+			})
+
+			expected := map[string][]diagnostic.Diagnostic{}
+			if tc.Message != "" {
+				expected = map[string][]diagnostic.Diagnostic{
+					"test-pdb": {{Message: tc.Message}},
+				}
+			}
+
+			p.Validate(p.ctx, []templates.TestCase{
+				{
+					Param:                    params.Params{},
+					Diagnostics:              expected,
+					ExpectInstantiationError: false,
+				},
+			})
+		})
+	}
 }


### PR DESCRIPTION
This PR fixes the PDB validation to include support for % based values.

OldBehavior:
maxUnavailable was set to 10% was failing since the field is IntOrString. The IntVal defaults to 0 when the field is of String Values, thus causing false positives.

NewBehaviour:
int and string values are taken into account, parsed into a single integer value for validation.

