### PR TITLE
pdbminavailable check - update label matching

### DIFF
--- a/pkg/templates/pdbminavailable/template.go
+++ b/pkg/templates/pdbminavailable/template.go
@@ -146,8 +146,14 @@ func getDeploymentLikeObjects(lintCtx lintcontext.LintContext, labelSelector lab
 		if err != nil {
 			return nil, err
 		}
+
+		objectLabels, err := labels.ConvertSelectorToLabelsMap(objLabelSelector.String())
+		if err != nil {
+			return nil, err
+		}
+
 		// Find any Deployment Likes with the same selector as the PDB
-		if labelSelector.String() == objLabelSelector.String() {
+		if labelSelector.Matches(objectLabels) {
 			objectList = append(objectList, obj.K8sObject)
 		}
 	}

--- a/pkg/templates/pdbminavailable/template_test.go
+++ b/pkg/templates/pdbminavailable/template_test.go
@@ -59,34 +59,75 @@ func (p *PDBTestSuite) TestPDBMinAvailableZero() {
 }
 
 func (p *PDBTestSuite) TestPDBMinAvailableReplicasEqual() {
-
-	p.ctx.AddMockDeployment(p.T(), "test-deploy")
-	p.ctx.ModifyDeployment(p.T(), "test-deploy", func(deployment *appsV1.Deployment) {
-		deployment.Namespace = "test"
-		deployment.Spec.Replicas = pointers.Int32(1)
-		deployment.Spec.Selector = &metaV1.LabelSelector{}
-		deployment.Spec.Selector.MatchLabels = map[string]string{"foo": "bar"}
-	})
-
-	p.ctx.AddMockPodDisruptionBudget(p.T(), "test-pdb")
-	p.ctx.ModifyPodDisruptionBudget(p.T(), "test-pdb", func(pdb *v1.PodDisruptionBudget) {
-		pdb.Namespace = "test"
-		pdb.Spec.Selector = &metaV1.LabelSelector{}
-		pdb.Spec.Selector.MatchLabels = map[string]string{"foo": "bar"}
-		pdb.Spec.MinAvailable = &intstr.IntOrString{IntVal: 1}
-	})
-
-	p.Validate(p.ctx, []templates.TestCase{
+	tests := []struct {
+		name           string
+		deploymentSpec appsV1.DeploymentSpec
+		pdbSpec        v1.PodDisruptionBudgetSpec
+	}{
 		{
-			Param: params.Params{},
-			Diagnostics: map[string][]diagnostic.Diagnostic{
-				"test-pdb": {
-					{Message: "The current number of replicas for deployment test-deploy is equal to or lower than the minimum number of replicas specified by its PDB."},
+			name: "replicas equal with matching labels",
+			deploymentSpec: appsV1.DeploymentSpec{
+				Replicas: pointers.Int32(1),
+				Selector: &metaV1.LabelSelector{
+					MatchLabels: map[string]string{"foo": "bar"},
 				},
 			},
-			ExpectInstantiationError: false,
+			pdbSpec: v1.PodDisruptionBudgetSpec{
+				Selector: &metaV1.LabelSelector{
+					MatchLabels: map[string]string{"foo": "bar"},
+				},
+				MinAvailable: &intstr.IntOrString{IntVal: 1},
+			},
 		},
-	})
+		{
+			name: "replicas equal with matching expression",
+			deploymentSpec: appsV1.DeploymentSpec{
+				Replicas: pointers.Int32(1),
+				Selector: &metaV1.LabelSelector{
+					MatchLabels: map[string]string{"foo": "bar"},
+				},
+			},
+			pdbSpec: v1.PodDisruptionBudgetSpec{
+				Selector: &metaV1.LabelSelector{
+					MatchExpressions: []metaV1.LabelSelectorRequirement{
+						{
+							Key:      "foo",
+							Operator: metaV1.LabelSelectorOpIn,
+							Values:   []string{"baz", "bar", "qux"},
+						},
+					},
+				},
+				MinAvailable: &intstr.IntOrString{IntVal: 1},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		p.T().Run(tt.name, func(t *testing.T) {
+			p.ctx.AddMockDeployment(p.T(), "test-deploy")
+			p.ctx.ModifyDeployment(p.T(), "test-deploy", func(deployment *appsV1.Deployment) {
+				deployment.Namespace = "test"
+				deployment.Spec = tt.deploymentSpec
+			})
+			p.ctx.AddMockPodDisruptionBudget(p.T(), "test-pdb")
+			p.ctx.ModifyPodDisruptionBudget(p.T(), "test-pdb", func(pdb *v1.PodDisruptionBudget) {
+				pdb.Namespace = "test"
+				pdb.Spec = tt.pdbSpec
+			})
+
+			p.Validate(p.ctx, []templates.TestCase{
+				{
+					Param: params.Params{},
+					Diagnostics: map[string][]diagnostic.Diagnostic{
+						"test-pdb": {
+							{Message: "The current number of replicas for deployment test-deploy is equal to or lower than the minimum number of replicas specified by its PDB."},
+						},
+					},
+					ExpectInstantiationError: false,
+				},
+			})
+		})
+	}
 }
 
 func (p *PDBTestSuite) TestPDBMinAvailableFiftyPercent() {


### PR DESCRIPTION
This extends the pdbminavailable check to also match a PDB with a match expression.