### PR TITLE
Fix get tag

### DIFF
--- a/get-tag
+++ b/get-tag
@@ -1,2 +1,2 @@
 #!/bin/sh
-git describe --exact-match HEAD  2>/dev/null || git describe --long --tags --abbrev=10 --dirty
+git describe --tags --abbrev=10 --dirty


### PR DESCRIPTION
Tested on local repo:
- no tag: https://github.com/janisz/kube-linter/actions/runs/5013272704/jobs/8986164954#step:9:12
- tag: https://github.com/janisz/kube-linter/actions/runs/5013278580/jobs/8986176077#step:9:12

Fixes: 
- https://github.com/stackrox/kube-linter/issues/548

Refs:
- https://github.com/actions/checkout/issues/272#issuecomment-1184535098