### PR TITLE
updated pre commit hook docker image version

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -17,4 +17,4 @@
   description: This hook runs kube-linter using the project's official docker image
   language: docker_image
   types: [yaml]
-  entry: stackrox/kube-linter:0.6.3 lint 
+  entry: stackrox/kube-linter:v0.6.4 lint 


### PR DESCRIPTION
pre-commit with docker image was returning the following error: Error response from daemon: manifest for stackrox/kube-linter:0.6.3 not found: manifest unknown: manifest unknown

The correct syntax would be `stackrox/kube-linter:v0.6.3`. Since a new version was released I took the liberty to update pre-commit one's.