### PR TITLE
group dependabot k8s updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,3 +16,7 @@ updates:
     open-pull-requests-limit: 3
     reviewers:
       - "janisz"
+    groups:
+      k8s.io:
+        patterns:
+          - "k8s.io/*"


### PR DESCRIPTION
Recent dependabot PR does not update all k8s deps causing build to fail. This should fix it.

- https://github.com/stackrox/kube-linter/pull/685