### PR TITLE
fix(Makefile): fix for path with spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ PATH := $(GOBIN):$(PATH)
 # and so, without the following line, the shell does not end up
 # trying commands in $(GOBIN) first.
 # See https://stackoverflow.com/a/36226784/3690207
-SHELL := env GOBIN=$(GOBIN) PATH=$(PATH) /bin/bash
+SHELL := env GOBIN=$(GOBIN) PATH="$(PATH)" /bin/bash
 
 KUBE_LINTER_BIN := $(GOBIN)/kube-linter
 


### PR DESCRIPTION
Double quote the path env var to allow paths to include spaces.