### PR TITLE
chore: release arm64 binaries

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,6 +19,7 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm64
     main: ./cmd/kube-linter
     flags:
       - "-mod=readonly"
@@ -31,11 +32,17 @@ builds:
 archives:
   - format: binary
     name_template: >-
-      {{ .ProjectName }}-{{ .Os }}
+      {{ .ProjectName }}
+      {{- if eq .Os "windows" }}
+      {{- else }}-{{ .Os }}{{ end }}
+      {{- if eq .Arch "amd64" }}
+      {{- else }}_{{ .Arch }}{{ end }}
   - id: archive
     format: tar.gz
     name_template: >-
       {{ .ProjectName }}-{{ .Os }}
+      {{- if eq .Arch "amd64" }}
+      {{- else }}_{{ .Arch }}{{ end }}
     # use zip for windows archives
     format_overrides:
       - goos: windows


### PR DESCRIPTION
Following files will be released:
```
# cat dist/kube-linter_0.6.7-SNAPSHOT-0c08521_checksums.txt
f1a9e71b1df55eb74e3e0e836fa33ffc6ae7f7cd590db052d836b4b4c1242701  kube-linter-darwin
18af0461afc85b136b478817735f600f08f53bb43ec72a125f37c57e014fcb3d  kube-linter-darwin.tar.gz
064ef9d2ea7fb639b64b47256d88b2c2eb523370b344ff7598e3852516a37ec3  kube-linter-darwin_arm64
4e379c1b322828e55e181076261c454416cf49bc75ca9705465afbdd87242d81  kube-linter-darwin_arm64.tar.gz
cfe72d6225641c76ab41b87338d648e4e0427bc020ec2e88d5055bbe816bb4b7  kube-linter-linux
cf9c3f8c0d890b68a1045f48221f2b4d4f7828716e12d7318811324fb55d090f  kube-linter-linux.tar.gz
e49310096163076bc368077eec8442ebd18ef3923fde1bd7caccb8ea730a8989  kube-linter-linux_arm64
f89f051571740f06a8b7939a105b2f510c041bea3eee33a449d447044d38873b  kube-linter-linux_arm64.tar.gz
ebed5fac24d983fbe0f2a1f4551d03ef71f6cbca3ebede2efe42fca24e79e15b  kube-linter-windows.zip
e1c6f7df55816dd64a37e09c336e2d5e09cf6245a57029cb018287439adbe70b  kube-linter-windows_arm64.zip
4794b8e5ce48897a5e4760d93610bf5ca5c9680327ee574cfd28f347bc0bcb08  kube-linter.exe
31dfcd01d1d504a9319f3011a4071593560b314ff46b4b710c7c208e97323868  kube-linter_arm64.exe
```

Closes:
- #691
- #404
- #701