### PR TITLE
chore: fix released files

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,10 +43,6 @@ archives:
       {{ .ProjectName }}-{{ .Os }}
       {{- if eq .Arch "amd64" }}
       {{- else }}_{{ .Arch }}{{ end }}
-    # use zip for windows archives
-    format_overrides:
-      - goos: windows
-        format: zip
 
 dockers:
   - dockerfile: image/Dockerfile
@@ -107,7 +103,7 @@ signs:
       - "--output-signature=${signature}"
       - "${artifact}"
       - "--yes"
-    artifacts: all
+    artifacts: binary
 
 docker_signs:
   - cmd: cosign


### PR DESCRIPTION
In order to keep backward compatibility for kube-linter-action we can't publish signatures for `tar.gz` as it breaks download script. We  can fix it but it will take some time until everyone upgrade. 
What's more kube-linter action for windows does not use `zip` but `tar.gz` for the same reason we need to bring this file back to releases. 
Due to limitation of goreleaser there is no easy way to have an artifact for a single arch. So we will not publish `zip`s for Windows builds.

Refs:
- https://github.com/stackrox/kube-linter/issues/380
- https://github.com/stackrox/kube-linter-action/issues/17
- https://github.com/stackrox/kube-linter-action/blob/3e0698d47a525061e50c1380af263c18824c748b/action.yml#L52
- https://github.com/goreleaser/goreleaser/issues/4644