### PR TITLE
fix: remove darwin shell hack in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,4 @@
-
-.PHONY: none
-none:
-
-
+.PHONY: deps
 deps: go.mod go.sum
 	@echo "+ $@"
 	@go mod tidy
@@ -22,12 +18,6 @@ GOBIN := $(CURDIR)/.gobin
 DIST := $(CURDIR)/dist
 PATH := $(DIST):$(GOBIN):$(PATH)
 
-# Makefile on Mac doesn't pass the updated PATH and GOBIN to the shell
-# and so, without the following line, the shell does not end up
-# trying commands in $(GOBIN) first.
-# See https://stackoverflow.com/a/36226784/3690207
-SHELL := env GOBIN=$(GOBIN) PATH=$(PATH) /bin/bash
-
 KUBE_LINTER_BIN := $(GOBIN)/kube-linter
 
 COVFILES := $(shell mktemp -d)
@@ -39,12 +29,12 @@ COVFILES := $(shell mktemp -d)
 GOLANGCILINT_BIN := $(GOBIN)/golangci-lint
 $(GOLANGCILINT_BIN): deps
 	@echo "+ $@"
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint
+	GOBIN=$(GOBIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint
 
 GORELEASER_BIN := $(GOBIN)/goreleaser
 $(GORELEASER_BIN): deps
 	@echo "+ $@"
-	go install github.com/goreleaser/goreleaser
+	GOBIN=$(GOBIN) go install github.com/goreleaser/goreleaser
 
 ###########
 ## Lint ##
@@ -56,9 +46,9 @@ ifdef CI
 	@echo '+ $@'
 	@echo 'The environment indicates we are in CI; running linters in check mode.'
 	@echo 'If this fails, run `make lint`.'
-	golangci-lint run
+	$(GOLANGCILINT_BIN) run
 else
-	golangci-lint run --fix
+	$(GOLANGCILINT_BIN) run --fix
 endif
 
 .PHONY: lint
@@ -89,7 +79,8 @@ generated-srcs: go-generated-srcs generated-docs
 build: $(KUBE_LINTER_BIN)
 
 $(KUBE_LINTER_BIN): $(GORELEASER_BIN) $(shell find . -type f -name '*.go')
-	goreleaser build --snapshot --clean
+	$(GORELEASER_BIN) build --snapshot --clean
+	mkdir -p $(GOBIN)
 	@cp "$(DIST)/kube-linter_$(HOST_OS)_amd64_v1/kube-linter" "$(GOBIN)/kube-linter"
 	@chmod u+w "$(GOBIN)/kube-linter"
 


### PR DESCRIPTION
This PR removes setting a `SHELL` as we no longer need it since we simplified our build process and call binaries with full path. The only places where `GOBIN` need to be passed is with `go install` and can be inlined without need to change it in shell.