### PR TITLE
Generate release tarballs with vendored modules with .goreleaser.yaml

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -124,3 +124,8 @@ docker_signs:
 
 changelog:
   use: github-native
+
+source:
+  enabled: true
+  files:
+    - vendor


### PR DESCRIPTION
Used for distros/circumstances where pulling external dependencies directly during build is not allowed.