### PR TITLE
chore: use only native caches from actions/setup-go and golangci/golangci-lint-action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,18 +29,6 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Go Build Cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache
-          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
-
-      - name: Go Mod Cache
-        uses: actions/cache@v4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
-
       - name: Build binaries
         run: make build
 
@@ -51,7 +39,10 @@ jobs:
           path: bin
 
       - name: Run lint checks
-        run: make lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.59.1
+
 
       - name: Ensure generated files are up-to-date
         run: make generated-srcs && git diff --exit-code HEAD


### PR DESCRIPTION
Those two steps are not of use anymore as caches are alredy handle by actions

* actions/setup-go@v5 
  * ~/.cache/go-build
  * ~/go/pkg/mod
* golangci/golangci-lint-action@v6
  * ~/.cache/golangci-lint