### PR TITLE
fix: dependabot directory tools path

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -21,7 +21,7 @@ updates:
         patterns:
           - "k8s.io/*"
   - package-ecosystem: 'gomod'
-    directory: 'tools-import'
+    directory: 'tool-imports'
     schedule:
       interval: 'weekly'
       day: 'wednesday'


### PR DESCRIPTION
This should fix us not getting any dependabot PRs for the `tool-imports` directory.