### PR TITLE
Do not ignore objects without pod template in `dangling-horizontalpodautoscaler`

### DIFF
--- a/pkg/templates/danglinghpa/template.go
+++ b/pkg/templates/danglinghpa/template.go
@@ -6,7 +6,6 @@ import (
 	"golang.stackrox.io/kube-linter/pkg/check"
 	"golang.stackrox.io/kube-linter/pkg/config"
 	"golang.stackrox.io/kube-linter/pkg/diagnostic"
-	"golang.stackrox.io/kube-linter/pkg/extract"
 	"golang.stackrox.io/kube-linter/pkg/lintcontext"
 	"golang.stackrox.io/kube-linter/pkg/objectkinds"
 	"golang.stackrox.io/kube-linter/pkg/templates"
@@ -79,10 +78,6 @@ func init() {
 					return nil
 				}
 				for _, obj := range lintCtx.Objects() {
-					_, hasPods := extract.PodTemplateSpec(obj.K8sObject)
-					if !hasPods {
-						continue
-					}
 					k8sObj := obj.K8sObject
 					gvk := k8sObj.GetObjectKind().GroupVersionKind()
 					if target.Name == obj.GetK8sObjectName().Name && target.Kind == gvk.Kind && target.APIVersion == gvk.Group+"/"+gvk.Version {


### PR DESCRIPTION
Fixes https://github.com/stackrox/kube-linter/issues/932.

I personally don't understand why the object referenced in the `scaleTargetRef` of the HPA needs to have a pod template in its manifest. I find this pre-condition to be out of scope for this check. The check should only ensure that the referenced object in `scaleTargetRef` exists in the linting context. There are way too many custom resources that have the `/scale` sub-resource without defining by default a pod template in their manifest.

I also checked the original PR https://github.com/stackrox/kube-linter/pull/271 implementing this check and I could not find any comment or commits explaining why this pre-condition is necessary.