### PR TITLE
Add simple CI usage documentation

### DIFF
--- a/docs/using-kubelinter.md
+++ b/docs/using-kubelinter.md
@@ -76,7 +76,7 @@ tar -xf kube-linter-linux.tar.gz -C "kube-linter/"
 ```
 and pass `--fail-on-invalid-resource` as an option to have your pipeline fail if your YAML file can't be parsed. See the following example:
 ```bash
-./kube-linter/kube-linter lint --fail-on-invalid-resource pod.yaml
+./kube-linter/kube-linter lint --fail-on-invalid-resource /path/to/yaml-file.yaml
 ```
 
 ## KubeLinter commands


### PR DESCRIPTION
Hi,

I added some basic documentation for using KubeLinter as part of a CI pipeline. While there is a Github Action available, I might not be the only one interested in running it elsewhere. I found the `--fail-on-invalid-resource` option especially important when dealing with manual changes to YAML files.

https://github.com/stackrox/kube-linter/issues/965