### PR TITLE
Add a basic schema validation for config files

### DIFF
--- a/schemas/kube-lint-config.json
+++ b/schemas/kube-lint-config.json
@@ -1,0 +1,89 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "KubeLinter Configuration",
+    "type": "object",
+    "properties": {
+        "checks": {
+            "type": "object",
+            "description": "Configure which built-in checks to run or skip",
+            "properties": {
+                "doNotAutoAddDefaults": {
+                    "type": "boolean",
+                    "description": "Disable all built-in checks"
+                },
+                "addAllBuiltIn": {
+                    "type": "boolean",
+                    "description": "Enable all built-in checks. Takes precedence over doNotAutoAddDefaults"
+                },
+                "ignorePaths": {
+                    "type": "array",
+                    "description": "File or directory globs to skip. Uses https://pkg.go.dev/github.com/bmatcuk/doublestar#Match syntax",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "include": {
+                    "type": "array",
+                    "description": "List of specific checks to run. Exclude always takes precedence over include",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "exclude": {
+                    "type": "array",
+                    "description": "List of specific checks to skip (takes precedence over include)",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "customChecks": {
+            "type": "array",
+            "description": "User-defined checks based on templates",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Unique identifier for this custom check"
+                    },
+                    "template": {
+                        "type": "string",
+                        "description": "Template name (e.g. required-annotation, required-label)"
+                    },
+                    "params": {
+                        "type": "object",
+                        "description": "Template-specific parameters",
+                        "additionalProperties": true
+                    },
+                    "scope": {
+                        "type": "object",
+                        "description": "Limit this check to certain Kubernetes object kinds",
+                        "properties": {
+                            "objectKinds": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "description": "E.g. DeploymentLike, Service. Supported values are listed in: https://github.com/stackrox/kube-linter/tree/main/pkg/objectkinds"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "remediation": {
+                        "type": "string",
+                        "description": "Custom message shown when this check fails"
+                    }
+                },
+                "required": [
+                    "name",
+                    "template"
+                ],
+                "additionalProperties": false
+            }
+        }
+    },
+    "additionalProperties": false
+}


### PR DESCRIPTION
Good for basic validation.
More work (and probably some CI automation?) would be needed for precisely validating each of the possible custom checks.

This should resolve: https://github.com/stackrox/kube-linter/issues/899