### PR TITLE
chore(lint): octalLiteral rule from go-critic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,7 +60,6 @@ linters:
       disabled-checks:
         - dupImport # https://github.com/go-critic/go-critic/issues/845
         - commentFormatting
-        - octalLiteral
         - unnamedResult
         - unnecessaryDefer
         - importShadow


### PR DESCRIPTION
#### Description

Enables and fixes [octalLiteral](https://go-critic.com/overview.html#octalliteral) rule from go-critic