### PR TITLE
chore(lint): enable misspell linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,7 +35,7 @@ linters:
     # - interfacer
     # - lll
     # - maligned
-    # - misspell
+    - misspell
     - nakedret
     # - nestif
     - nolintlint

--- a/pkg/templates/pdbminavailable/template.go
+++ b/pkg/templates/pdbminavailable/template.go
@@ -111,7 +111,7 @@ func minAvailableCheck(lintCtx lintcontext.LintContext, object lintcontext.Objec
 			replicas = transformReplicaIntoMinReplicas(dl, hpa, replicas)
 		}
 		if isPercent {
-			// Calulate the actual value of the MinAvailable with respect to the Replica count if a percentage is set
+			// Calculate the actual value of the MinAvailable with respect to the Replica count if a percentage is set
 			pdbMinAvailable = int(math.Ceil(float64(replicas) * (float64(value) / float64(100))))
 		}
 		//nolint:gosec // Integer conversion should be safe here since the kube api uses int32.


### PR DESCRIPTION
#### Description

Enables and fixes [misspell](https://golangci-lint.run/usage/linters/#misspell) linter