### PR TITLE
fix: wrong condition in CPU and memory validation

### DIFF
--- a/pkg/templates/cpurequirements/template.go
+++ b/pkg/templates/cpurequirements/template.go
@@ -15,7 +15,7 @@ import (
 )
 
 func process(results *[]diagnostic.Diagnostic, containerName, requirementsType string, quantity *resource.Quantity, lowerBound int, upperBound *int) {
-	if util.ValueInRange(int(quantity.MilliValue()), lowerBound, upperBound) {
+	if !util.ValueInRange(int(quantity.MilliValue()), lowerBound, upperBound) {
 		*results = append(*results, diagnostic.Diagnostic{
 			Message: fmt.Sprintf("container %q has cpu %s %s", containerName, requirementsType, quantity),
 		})

--- a/pkg/templates/memoryrequirements/template.go
+++ b/pkg/templates/memoryrequirements/template.go
@@ -20,7 +20,7 @@ const (
 )
 
 func process(results *[]diagnostic.Diagnostic, containerName, requirementsType string, quantity *resource.Quantity, lowerBoundBytes int, upperBoundBytes *int) {
-	if util.ValueInRange(int(quantity.Value()), lowerBoundBytes, upperBoundBytes) {
+	if !util.ValueInRange(int(quantity.Value()), lowerBoundBytes, upperBoundBytes) {
 		*results = append(*results, diagnostic.Diagnostic{
 			Message: fmt.Sprintf("container %q has memory %s %s", containerName, requirementsType, quantity),
 		})


### PR DESCRIPTION
The condition using `util.ValueInRange` was reversed, so errors were reported for valid values. Now it correctly reports errors only when values are out of range.