### PR TITLE
Fix nil pointer dereference in pdbminavailable check

### DIFF
--- a/pkg/templates/pdbminavailable/template.go
+++ b/pkg/templates/pdbminavailable/template.go
@@ -76,6 +76,15 @@ func minAvailableCheck(lintCtx lintcontext.LintContext, object lintcontext.Objec
 		}
 	}
 
+	// Check if selector is present - it's a required field for PDB
+	if pdb.Spec.Selector == nil {
+		return []diagnostic.Diagnostic{
+			{
+				Message: "PDB is missing required selector field: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget",
+			},
+		}
+	}
+
 	// Build the label selector for the PDB to use for comparison
 	labelSelector, err := metaV1.LabelSelectorAsSelector(&metaV1.LabelSelector{
 		MatchLabels:      pdb.Spec.Selector.MatchLabels,


### PR DESCRIPTION
The pdbminavailable check crashed with a panic when it encountered a PodDisruptionBudget that has spec.minAvailable defined but is missing the required spec.selector field.

The code attempted to access pdb.Spec.Selector.MatchLabels and pdb.Spec.Selector.MatchExpressions without checking if Selector was nil, causing a nil pointer dereference.

This fix adds a nil check for pdb.Spec.Selector before accessing its fields. If the selector is missing, the check now returns a clear diagnostic message with a link to Kubernetes documentation instead of panicking.

Also added a unit test TestPDBWithMinAvailableButNoSelector to verify the fix handles this edge case correctly.

Fixes #1041

🤖 Generated with [Claude Code](https://claude.com/claude-code)