### PR TITLE
chore: upgrade cosign to v3 bundle format

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -140,11 +140,12 @@ checksum:
 signs:
   - cmd: cosign
     stdin: "{{ .Env.COSIGN_PASSWORD }}"
+    signature: "${artifact}.sigstore.json"
     args:
       - "sign-blob"
       - "--key"
       - "env://KEY"
-      - "--output-signature=${signature}"
+      - "--bundle=${signature}"
       - "${artifact}"
       - "--yes"
     artifacts: binary


### PR DESCRIPTION
Update .goreleaser.yaml to use the new cosign v3 bundle format which simplifies the signing workflow by using a single .sigstore.json file instead of separate .pem certificate and .sig signature files.

Refs: https://github.com/goreleaser/goreleaser/blob/16e3bba54c58bc7e0bafea9c19fafc55aeb2a1e4/www/docs/blog/posts/2025-11-05-cosign-v3.md?plain=1#L10

🤖 Generated with [Claude Code](https://claude.com/claude-code)