### PR TITLE
fix(deps): bump k8s-manifests-lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/goccy/go-yaml v1.19.2
 	github.com/google/cel-go v0.28.1
-	github.com/lburgazzoli/k8s-manifests-lib v0.1.4-0.20251117120254-104132b6a2be
+	github.com/lburgazzoli/k8s-manifests-lib v0.1.4-0.20260603051037-da973e140f6f
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c
 	github.com/openshift/api v0.0.0-20230406152840-ce21e3fe5da2

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/goccy/go-yaml v1.19.2
 	github.com/google/cel-go v0.28.1
-	github.com/lburgazzoli/k8s-manifests-lib v0.1.4-0.20260603051037-da973e140f6f
+	github.com/lburgazzoli/k8s-manifests-lib v0.1.4-0.20260604152250-c709b6bbaabb
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c
 	github.com/openshift/api v0.0.0-20230406152840-ce21e3fe5da2

--- a/go.sum
+++ b/go.sum
@@ -223,8 +223,8 @@ github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhR
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
 github.com/lburgazzoli/gomega-matchers v0.1.1 h1:it5XiuJGJB2Noq1KayamTgEe7Ls2/Cycezt3g6xyuo4=
 github.com/lburgazzoli/gomega-matchers v0.1.1/go.mod h1:sTPi8iTNViVEDJujnMzYicDshmo6G4rl9+gF/O02/V8=
-github.com/lburgazzoli/k8s-manifests-lib v0.1.4-0.20260603051037-da973e140f6f h1:v/8+RJlvWRbnUf9xBWfOQcJ3DUslArZ/HvTtqUm5qbU=
-github.com/lburgazzoli/k8s-manifests-lib v0.1.4-0.20260603051037-da973e140f6f/go.mod h1:KbU9qYnaBuQ9pzy5eouAouaA/VdvKB1I00y20NEqxj8=
+github.com/lburgazzoli/k8s-manifests-lib v0.1.4-0.20260604152250-c709b6bbaabb h1:4nioLkiz7/rBE6eBcZoFZ4pvNk8AZ3k+lK9TgUrl4n8=
+github.com/lburgazzoli/k8s-manifests-lib v0.1.4-0.20260604152250-c709b6bbaabb/go.mod h1:KbU9qYnaBuQ9pzy5eouAouaA/VdvKB1I00y20NEqxj8=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.11.2 h1:x6gxUeu39V0BHZiugWe8LXZYZ+Utk7hSJGThs8sdzfs=
 github.com/lib/pq v1.11.2/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=

--- a/go.sum
+++ b/go.sum
@@ -223,8 +223,8 @@ github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhR
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
 github.com/lburgazzoli/gomega-matchers v0.1.1 h1:it5XiuJGJB2Noq1KayamTgEe7Ls2/Cycezt3g6xyuo4=
 github.com/lburgazzoli/gomega-matchers v0.1.1/go.mod h1:sTPi8iTNViVEDJujnMzYicDshmo6G4rl9+gF/O02/V8=
-github.com/lburgazzoli/k8s-manifests-lib v0.1.4-0.20251117120254-104132b6a2be h1:NUk3nkp6vkvRgARJpG+gvGaTQ6VrEZCBaKZXQ7xohKc=
-github.com/lburgazzoli/k8s-manifests-lib v0.1.4-0.20251117120254-104132b6a2be/go.mod h1:KbU9qYnaBuQ9pzy5eouAouaA/VdvKB1I00y20NEqxj8=
+github.com/lburgazzoli/k8s-manifests-lib v0.1.4-0.20260603051037-da973e140f6f h1:v/8+RJlvWRbnUf9xBWfOQcJ3DUslArZ/HvTtqUm5qbU=
+github.com/lburgazzoli/k8s-manifests-lib v0.1.4-0.20260603051037-da973e140f6f/go.mod h1:KbU9qYnaBuQ9pzy5eouAouaA/VdvKB1I00y20NEqxj8=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.11.2 h1:x6gxUeu39V0BHZiugWe8LXZYZ+Utk7hSJGThs8sdzfs=
 github.com/lib/pq v1.11.2/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=


### PR DESCRIPTION
## Summary

Bumps `github.com/lburgazzoli/k8s-manifests-lib` to include the Windows Kustomize unionfs fix from lburgazzoli/k8s-manifests-lib#8.

This fixes the stack overflow reported in #1195 when linting repositories with Kustomize manifests on Windows.

## Testing

- Fork CI passed: https://github.com/gologames/kube-linter/pull/1
- Regression check on Windows: kube-linter no longer crashes with stack overflow and returns normal lint findings.