### PR TITLE
Avoid env-var-secret false positives for SECRETS_* names

### DIFF
--- a/docs/generated/checks.md
+++ b/docs/generated/checks.md
@@ -222,7 +222,7 @@ IgnoredSecrets: []
 **Parameters**:
 
 ```yaml
-name: (?i).*secret.*
+name: (?i).*secret([^s].*|$)
 value: .+
 ```
 ## exposed-services

--- a/pkg/builtinchecks/yamls/env-var-secret.yaml
+++ b/pkg/builtinchecks/yamls/env-var-secret.yaml
@@ -8,5 +8,5 @@ scope:
     - DeploymentLike
 template: "env-var"
 params:
-  name: "(?i).*secret.*"
+  name: "(?i).*secret([^s].*|$)"
   value: ".+"

--- a/tests/checks/env-var-secret.yml
+++ b/tests/checks/env-var-secret.yml
@@ -28,6 +28,19 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: secrets-dir
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          env:
+            - name: SECRETS_DIR
+              value: /mnt/secrets
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: app
 spec:
   template:


### PR DESCRIPTION
Fixes #1198.

The built-in `env-var-secret` check used `(?i).*secret.*`, which also matched names like `SECRETS_DIR`.

This narrows the built-in pattern so plural `secrets` suffixes are not flagged, and extends the fixture with a `SECRETS_DIR` case to keep that behavior covered.

Verification:
- go test ./pkg/builtinchecks/...
- go run ./cmd/kube-linter lint --include env-var-secret --do-not-auto-add-defaults --format json tests/checks/env-var-secret.yml