### PR TITLE
chore(deps): bump go directive to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module golang.stackrox.io/kube-linter
 
-go 1.26.1
+go 1.26.4
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0


### PR DESCRIPTION
The `go` directive in `go.mod` is pinned to `1.26.1`. That patch still carries the stdlib advisories that were fixed across 1.26.2–1.26.4.

`build.yaml` sets up Go with `go-version-file: go.mod`, so CI keeps building and testing on 1.26.1, and anyone building from source inherits the same floor. Bumping the directive to 1.26.4 pulls in the patched stdlib.

Module dependencies are already current on `main`, so this is toolchain-only — `go mod tidy` is otherwise a no-op.

Checked locally before opening:
- `go build ./...` and `go vet ./...` pass
- `go test ./...` passes
- `govulncheck ./...` reports no vulnerabilities