### PR TITLE
Add OpenShift Route security check

### DIFF
--- a/docs/generated/checks.md
+++ b/docs/generated/checks.md
@@ -284,6 +284,22 @@ forbiddenServiceTypes:
 ```yaml
 minReplicas: 3
 ```
+## insecure-route-termination
+
+**Enabled by default**: No
+
+**Description**: OpenShift Route allows plaintext HTTP via InsecureEdgeTerminationPolicy: Allow. Credential-bearing endpoints should enforce TLS by using Redirect or None.
+
+**Remediation**: Set spec.tls.insecureEdgeTerminationPolicy to 'Redirect' or 'None'.
+
+**Template**: [cel-expression](templates.md#cel)
+
+**Parameters**:
+
+```yaml
+check: |
+  object.kind == 'Route' && has(object.spec.tls) && has(object.spec.tls.insecureEdgeTerminationPolicy) && object.spec.tls.insecureEdgeTerminationPolicy == 'Allow' ? 'Route allows plaintext HTTP — credential-bearing endpoints should use Redirect or None' : ''
+```
 ## invalid-target-ports
 
 **Enabled by default**: Yes

--- a/e2etests/bats-tests.sh
+++ b/e2etests/bats-tests.sh
@@ -435,6 +435,19 @@ get_value_from() {
   [[ "${count}" == "1" ]]
 }
 
+@test "insecure-route-termination" {
+  tmp="tests/checks/insecure-route-termination.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include insecure-route-termination --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${count}" == "1" ]]
+}
+
 @test "invalid-target-ports" {
   tmp="tests/checks/invalid-target-ports.yaml"
   cmd="${KUBE_LINTER_BIN} lint --include invalid-target-ports --do-not-auto-add-defaults --format json ${tmp}"
@@ -1242,17 +1255,4 @@ get_value_from() {
 
   # Cleanup
   rm -f ${json_out} ${sarif_out}
-}
-
-@test "insecure-route-termination" {
-  tmp="tests/checks/insecure-route-termination.yml"
-  cmd="${KUBE_LINTER_BIN} lint --include insecure-route-termination --do-not-auto-add-defaults --format json ${tmp}"
-  run ${cmd}
-
-  print_info "${status}" "${output}" "${cmd}" "${tmp}"
-  [ "$status" -eq 1 ]
-
-  count=$(get_value_from "${lines[0]}" '.Reports | length')
-
-  [[ "${count}" == "1" ]]
 }

--- a/e2etests/bats-tests.sh
+++ b/e2etests/bats-tests.sh
@@ -1244,3 +1244,15 @@ get_value_from() {
   rm -f ${json_out} ${sarif_out}
 }
 
+@test "insecure-route-termination" {
+  tmp="tests/checks/insecure-route-termination.yml"
+  cmd="${KUBE_LINTER_BIN} lint --include insecure-route-termination --do-not-auto-add-defaults --format json ${tmp}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 1 ]
+
+  count=$(get_value_from "${lines[0]}" '.Reports | length')
+
+  [[ "${count}" == "1" ]]
+}

--- a/pkg/builtinchecks/yamls/insecure-route-termination.yaml
+++ b/pkg/builtinchecks/yamls/insecure-route-termination.yaml
@@ -1,0 +1,17 @@
+name: insecure-route-termination
+description: >-
+  OpenShift Route allows plaintext HTTP via InsecureEdgeTerminationPolicy: Allow.
+  Credential-bearing endpoints should enforce TLS by using Redirect or None.
+remediation: >-
+  Set spec.tls.insecureEdgeTerminationPolicy to 'Redirect' or 'None'.
+scope:
+  objectKinds:
+    - Any
+template: cel-expression
+params:
+  check: >
+    object.kind == 'Route' &&
+    has(object.spec.tls) &&
+    has(object.spec.tls.insecureEdgeTerminationPolicy) &&
+    object.spec.tls.insecureEdgeTerminationPolicy == 'Allow'
+    ? 'Route allows plaintext HTTP — credential-bearing endpoints should use Redirect or None' : ''

--- a/tests/checks/insecure-route-termination.yml
+++ b/tests/checks/insecure-route-termination.yml
@@ -1,0 +1,45 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: dont-fire-redirect
+spec:
+  to:
+    kind: Service
+    name: my-service
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: dont-fire-none
+spec:
+  to:
+    kind: Service
+    name: my-service
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: None
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: fire-allow-insecure
+spec:
+  to:
+    kind: Service
+    name: my-service
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Allow
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dont-fire-not-a-route
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80


### PR DESCRIPTION
## Summary
- Add `insecure-route-termination` check for OpenShift Routes with `InsecureEdgeTerminationPolicy: Allow`
- Uses existing `cel-expression` template with `objectKinds: [Any]` and a kind guard for Route objects
- No Go code changes — pure YAML check definition

## New Check

| Check | Severity | What it detects |
|-------|----------|----------------|
| `insecure-route-termination` | Medium | OpenShift Routes permitting plaintext HTTP via InsecureEdgeTerminationPolicy: Allow |

## Notes
- The check uses `objectKinds: [Any]` with a `object.kind == 'Route'` guard since Route is an OpenShift-specific CRD
- The kind guard short-circuits evaluation for non-Route objects, so there is no performance impact on non-OpenShift clusters

## Test plan
- [ ] Test manifest includes Routes with Redirect (pass), None (pass), Allow (fail), and a non-Route Service (pass)
- [ ] Uses existing cel-expression template — no new dependencies

---
> **Note:** This PR was created with AI assistance using Claude Code.