### PR TITLE
test(memoryrequirements): add regression test for init+regular containers with limits set

### DIFF
--- a/pkg/lintcontext/mocks/container.go
+++ b/pkg/lintcontext/mocks/container.go
@@ -15,3 +15,10 @@ func (l *MockLintContext) AddContainerToDeployment(t *testing.T, deploymentName 
 	// TODO: keep supporting other fields
 	deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, container)
 }
+
+// AddInitContainerToDeployment adds a mock init container to the specified pod under context
+func (l *MockLintContext) AddInitContainerToDeployment(t *testing.T, deploymentName string, container v1.Container) {
+	deployment, ok := l.objects[deploymentName].(*appsV1.Deployment)
+	require.True(t, ok, "deployment with name %s not found", deploymentName)
+	deployment.Spec.Template.Spec.InitContainers = append(deployment.Spec.Template.Spec.InitContainers, container)
+}

--- a/pkg/templates/memoryrequirements/template.go
+++ b/pkg/templates/memoryrequirements/template.go
@@ -17,6 +17,8 @@ import (
 
 const (
 	bytesInMB = 1024 * 1024
+
+	templateKey = "memory-requirements"
 )
 
 func process(results *[]diagnostic.Diagnostic, containerName, requirementsType string, quantity *resource.Quantity, lowerBoundBytes int, upperBoundBytes *int) {
@@ -30,7 +32,7 @@ func process(results *[]diagnostic.Diagnostic, containerName, requirementsType s
 func init() {
 	templates.Register(check.Template{
 		HumanName:   "Memory Requirements",
-		Key:         "memory-requirements",
+		Key:         templateKey,
 		Description: "Flag containers with memory requirements in the given range",
 		SupportedObjectKinds: config.ObjectKindsDesc{
 			ObjectKinds: []string{objectkinds.DeploymentLike},

--- a/pkg/templates/memoryrequirements/template_test.go
+++ b/pkg/templates/memoryrequirements/template_test.go
@@ -1,0 +1,92 @@
+package memoryrequirements
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"golang.stackrox.io/kube-linter/internal/pointers"
+	"golang.stackrox.io/kube-linter/pkg/diagnostic"
+	"golang.stackrox.io/kube-linter/pkg/lintcontext/mocks"
+	"golang.stackrox.io/kube-linter/pkg/templates"
+	"golang.stackrox.io/kube-linter/pkg/templates/memoryrequirements/internal/params"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestMemoryRequirements(t *testing.T) {
+	suite.Run(t, new(MemoryRequirementsTestSuite))
+}
+
+type MemoryRequirementsTestSuite struct {
+	templates.TemplateTestSuite
+
+	ctx *mocks.MockLintContext
+}
+
+func (s *MemoryRequirementsTestSuite) SetupTest() {
+	s.Init(templateKey)
+	s.ctx = mocks.NewMockContext()
+}
+
+func requirements(memoryMB int64) v1.ResourceRequirements {
+	return v1.ResourceRequirements{
+		Requests: v1.ResourceList{v1.ResourceMemory: *resource.NewQuantity(memoryMB*bytesInMB, resource.BinarySI)},
+		Limits:   v1.ResourceList{v1.ResourceMemory: *resource.NewQuantity(memoryMB*bytesInMB, resource.BinarySI)},
+	}
+}
+
+// TestInitAndRegularContainersWithLimitsSet is a regression test for
+// https://github.com/stackrox/kube-linter/issues/428: a deployment where both
+// init and regular containers have memory requirements set should not be flagged.
+func (s *MemoryRequirementsTestSuite) TestInitAndRegularContainersWithLimitsSet() {
+	const deploymentName = "dep-with-init-and-regular-containers"
+	s.ctx.AddMockDeployment(s.T(), deploymentName)
+	s.ctx.AddInitContainerToDeployment(s.T(), deploymentName, v1.Container{
+		Name:      "init",
+		Resources: requirements(128),
+	})
+	s.ctx.AddContainerToDeployment(s.T(), deploymentName, v1.Container{
+		Name:      "app",
+		Resources: requirements(128),
+	})
+
+	s.Validate(s.ctx, []templates.TestCase{
+		{
+			Param: params.Params{
+				RequirementsType: "limit",
+				UpperBoundMB:     pointers.Int(0),
+			},
+			Diagnostics: map[string][]diagnostic.Diagnostic{
+				deploymentName: nil,
+			},
+		},
+	})
+}
+
+// TestInitContainerMissingLimitIsFlagged ensures that an init container without
+// memory requirements is still flagged, even when a sibling regular container has
+// its requirements set.
+func (s *MemoryRequirementsTestSuite) TestInitContainerMissingLimitIsFlagged() {
+	const deploymentName = "dep-with-init-container-missing-limit"
+	s.ctx.AddMockDeployment(s.T(), deploymentName)
+	s.ctx.AddInitContainerToDeployment(s.T(), deploymentName, v1.Container{Name: "init"})
+	s.ctx.AddContainerToDeployment(s.T(), deploymentName, v1.Container{
+		Name:      "app",
+		Resources: requirements(128),
+	})
+
+	s.Validate(s.ctx, []templates.TestCase{
+		{
+			Param: params.Params{
+				RequirementsType: "limit",
+				UpperBoundMB:     pointers.Int(0),
+			},
+			Diagnostics: map[string][]diagnostic.Diagnostic{
+				deploymentName: {
+					{Message: `container "init" has memory limit 0`},
+				},
+			},
+		},
+	})
+}

--- a/pkg/templates/memoryrequirements/template_test.go
+++ b/pkg/templates/memoryrequirements/template_test.go
@@ -54,7 +54,7 @@ func (s *MemoryRequirementsTestSuite) TestInitAndRegularContainersWithLimitsSet(
 	s.Validate(s.ctx, []templates.TestCase{
 		{
 			Param: params.Params{
-				RequirementsType: "limit",
+				RequirementsType: "any",
 				UpperBoundMB:     pointers.Int(0),
 			},
 			Diagnostics: map[string][]diagnostic.Diagnostic{


### PR DESCRIPTION
Motivation:
Issue #428 reported that unset-memory-requirements produced a false
positive on a Deployment with both initContainers and containers when
resources were set on both. Reproducing this against current main with
a hand-built kube-linter binary and a Deployment YAML containing an
initContainer and a regular container, each with memory/cpu requests
and limits set, shows the check now correctly reports no violations.
The fix landed via earlier work (PodSpec.AllContainers(), used by
util.PerContainerCheck) that iterates init, regular, and ephemeral
containers while checking each container's own Resources field
independently. There was, however, no test locking in this behavior,
so the scenario could regress silently.

Approach:
- Add memoryrequirements/template_test.go using the repo's
  templates.TemplateTestSuite, covering:
  - an init container and a regular container both with memory
    requests/limits set -> no diagnostics (the exact #428 scenario).
  - an init container missing resources alongside a regular container
    that has them set -> the init container is still correctly
    flagged by name, proving the check isn't vacuously passing.
- Add AddInitContainerToDeployment to pkg/lintcontext/mocks/container.go,
  mirroring the existing AddContainerToDeployment helper, since no mock
  helper previously existed for populating a Deployment's init
  containers in tests.
- Extract the "memory-requirements" string literal into a templateKey
  const in template.go (matching the convention already used by
  sibling templates such as latesttag) so the new test can reference it
  via s.Init(templateKey).

Validation:
- go build ./...
- go test ./pkg/templates/memoryrequirements/... ./pkg/lintcontext/mocks/... (pass)
- go test ./... (all packages pass)
- golangci-lint run ./pkg/templates/memoryrequirements/... ./pkg/lintcontext/mocks/... (clean)

Impact: this is test-only coverage, not a functional fix. The
unset-memory-requirements/unset-cpu-requirements checks already behave
correctly on current main for the reported scenario; user-visible
behavior is unchanged. The benefit is a regression guard preventing
this specific false positive from silently reappearing.

Fixes #428

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>