### PR TITLE
fix: report manifests that fail to decode instead of dropping them si…

### DIFF
--- a/e2etests/invalid_object_test.go
+++ b/e2etests/invalid_object_test.go
@@ -1,0 +1,98 @@
+//go:build e2e
+
+package e2etests
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression test for #591 / #669.
+//
+// A manifest of a known kind that fails to decode used to be silently downgraded to an
+// unstructured object. It then became invisible to every pod-spec based check, and the only
+// thing the user saw was an unrelated dangling-service diagnostic about a *different* object.
+// KubeLinter must say which file it could not read, without needing --verbose.
+func TestKubeLinterReportsUndecodableObjectsWithoutVerbose(t *testing.T) {
+	kubeLinterBin := os.Getenv(kubeLinterBinEnv)
+	require.NotEmpty(t, kubeLinterBin, "Please set %s", kubeLinterBinEnv)
+
+	cases := map[string]struct {
+		manifest    string
+		wantInError string
+	}{
+		// #591: an invalid resource quantity.
+		"invalid quantity": {
+			manifest: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment
+spec:
+  selector:
+    matchLabels:
+      name: my-label-value
+  template:
+    metadata:
+      labels:
+        name: my-label-value
+    spec:
+      containers:
+        - name: my-container
+          image: nginx:latest
+          resources:
+            limits:
+              cpu: 10wrong_unit
+`,
+			wantInError: "quantities must match",
+		},
+		// #669: a number where the schema wants a string.
+		"number instead of string": {
+			manifest: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment
+spec:
+  selector:
+    matchLabels:
+      name: my-label-value
+  template:
+    metadata:
+      labels:
+        name: my-label-value
+    spec:
+      containers:
+        - name: my-container
+          image: nginx:latest
+          livenessProbe:
+            exec:
+              command:
+                - /usr/bin/echo
+                - 1234
+`,
+			wantInError: "cannot unmarshal number",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "manifest.yaml")
+			require.NoError(t, os.WriteFile(path, []byte(c.manifest), 0644))
+
+			// Deliberately no --verbose: the user must be told anyway.
+			out, _ := exec.Command(kubeLinterBin, "lint", path).CombinedOutput()
+			outAsStr := string(out)
+
+			assert.True(t, strings.Contains(outAsStr, "failed to load object"),
+				"expected a load failure to be reported, got: %s", outAsStr)
+			assert.True(t, strings.Contains(outAsStr, c.wantInError),
+				"expected the report to name the real cause %q, got: %s", c.wantInError, outAsStr)
+		})
+	}
+}

--- a/pkg/command/lint/command.go
+++ b/pkg/command/lint/command.go
@@ -105,10 +105,11 @@ func Command() *cobra.Command {
 				return err
 			}
 			invalidObjectsResult := generateReportFromInvalidObjects(lintCtxs)
-			if verbose {
-				for _, invalidObj := range invalidObjectsResult {
-					_, _ = fmt.Fprintf(os.Stderr, "Warning: failed to load object from %s: %v\n", invalidObj.Object.Metadata.FilePath, invalidObj.Diagnostic.Message)
-				}
+			// Objects we failed to load are silently missing from every check that would
+			// have applied to them, which surfaces as an unrelated diagnostic somewhere
+			// else (see #591). Always tell the user what we could not read.
+			for _, invalidObj := range invalidObjectsResult {
+				_, _ = fmt.Fprintf(os.Stderr, "Warning: failed to load object from %s: %v\n", invalidObj.Object.Metadata.FilePath, invalidObj.Diagnostic.Message)
 			}
 
 			var atLeastOneObjectFound = errorOnInvalidResource && len(invalidObjectsResult) > 0

--- a/pkg/lintcontext/parse_yaml.go
+++ b/pkg/lintcontext/parse_yaml.go
@@ -68,6 +68,13 @@ func parseObjects(data []byte, d runtime.Decoder) ([]k8sutil.Object, error) {
 		if strings.Contains(err.Error(), "json: cannot unmarshal") {
 			return nil, fmt.Errorf("failed to decode: %w", err)
 		}
+		// The fallback below exists for custom resources, whose Go types we do not know.
+		// If the kind is registered, the manifest is simply invalid: decoding it as
+		// unstructured would swallow the real error and, worse, hide the object from every
+		// check that relies on its typed representation (see extract.PodTemplateSpec).
+		if !runtime.IsNotRegisteredError(err) {
+			return nil, fmt.Errorf("failed to decode: %w", err)
+		}
 		// fallback to unstructured as schema validation will be performed by kubeconform check
 		dec := runtimeYaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
 		var unstructuredErr error

--- a/pkg/lintcontext/parse_yaml.go
+++ b/pkg/lintcontext/parse_yaml.go
@@ -184,13 +184,28 @@ func (l *lintContextImpl) renderTgzHelmChart(tgzFile string) (map[string]string,
 	return l.renderChart(tgzFile, chrt)
 }
 
+// isBlankDocument reports whether a YAML document carries no content at all: every
+// line is blank, a comment, or a bare document marker. Files that separate sections
+// with "--- # some comment" produce such documents, and there is nothing in them to
+// decode - reporting them as unreadable objects would be a false positive.
+func isBlankDocument(doc []byte) bool {
+	for _, line := range bytes.Split(doc, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 || line[0] == '#' || bytes.Equal(line, []byte("---")) || bytes.Equal(line, []byte("...")) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
 func (l *lintContextImpl) loadObjectFromYAMLReader(filePath string, r *yaml.YAMLReader) error {
 	doc, err := r.Read()
 	if err != nil {
 		return err
 	}
 	doc = bytes.TrimSpace(doc)
-	if len(doc) == 0 {
+	if len(doc) == 0 || isBlankDocument(doc) {
 		return nil
 	}
 

--- a/pkg/lintcontext/parse_yaml_invalid_object_test.go
+++ b/pkg/lintcontext/parse_yaml_invalid_object_test.go
@@ -1,6 +1,7 @@
 package lintcontext
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -89,4 +90,39 @@ spec:
 	require.NoError(t, err)
 	require.Len(t, objects, 1)
 	assert.IsType(t, &appsV1.Deployment{}, objects[0])
+}
+
+// Reporting unreadable manifests must not turn section separators into findings.
+// A document that holds nothing but comments carries no manifest at all, so it is
+// neither a valid object nor an invalid one.
+func TestLoadObjectsFromReaderSkipsCommentOnlyDocuments(t *testing.T) {
+	const doc = `---
+# Secret test cases
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment
+spec:
+  selector:
+    matchLabels:
+      name: my-label-value
+  template:
+    metadata:
+      labels:
+        name: my-label-value
+    spec:
+      containers:
+        - name: my-container
+          image: nginx:latest
+---
+# ConfigMap test cases
+---
+`
+
+	ctx := newCtx(Options{})
+	require.NoError(t, ctx.loadObjectsFromReader("test.yaml", strings.NewReader(doc)))
+	assert.Empty(t, ctx.InvalidObjects(), "comment-only documents must not be reported as unreadable")
+	require.Len(t, ctx.Objects(), 1)
+	assert.Equal(t, "my-deployment", ctx.Objects()[0].K8sObject.GetName())
 }

--- a/pkg/lintcontext/parse_yaml_invalid_object_test.go
+++ b/pkg/lintcontext/parse_yaml_invalid_object_test.go
@@ -1,0 +1,92 @@
+package lintcontext
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsV1 "k8s.io/api/apps/v1"
+)
+
+// Regression test for #591: a manifest of a *known* kind that fails to decode must be
+// reported as an invalid object instead of being silently downgraded to Unstructured.
+// The downgrade makes the workload invisible to every pod-spec based check, so the user
+// gets an unrelated diagnostic (dangling-service) and never learns about the real problem.
+func TestParseObjectsKnownKindWithInvalidValueIsReported(t *testing.T) {
+	const brokenDeployment = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment
+spec:
+  selector:
+    matchLabels:
+      name: my-label-value
+  template:
+    metadata:
+      labels:
+        name: my-label-value
+    spec:
+      containers:
+        - name: my-container
+          image: nginx:latest
+          resources:
+            limits:
+              cpu: 10wrong_unit
+`
+
+	objects, err := parseObjects([]byte(brokenDeployment), nil)
+	assert.Error(t, err, "a Deployment with an invalid quantity must not parse silently")
+	assert.Empty(t, objects)
+	if err != nil {
+		assert.Contains(t, err.Error(), "quantities must match", "the error must name the real cause")
+	}
+}
+
+// The fallback to unstructured exists for custom resources whose Go type we do not know.
+// That case must keep working: only *registered* kinds are held to the typed decoder.
+func TestParseObjectsUnknownKindStillFallsBackToUnstructured(t *testing.T) {
+	const tektonTask = `apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: my-task
+spec:
+  steps:
+    - name: echo
+      image: alpine
+`
+
+	objects, err := parseObjects([]byte(tektonTask), nil)
+	require.NoError(t, err, "custom resources must still parse as unstructured")
+	require.Len(t, objects, 1)
+	assert.Equal(t, "Task", objects[0].GetObjectKind().GroupVersionKind().Kind)
+}
+
+// A valid manifest of a known kind must still decode into its typed Go representation,
+// otherwise the checks that rely on extract.PodTemplateSpec silently stop seeing it.
+func TestParseObjectsValidKnownKindStaysTyped(t *testing.T) {
+	const okDeployment = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment
+spec:
+  selector:
+    matchLabels:
+      name: my-label-value
+  template:
+    metadata:
+      labels:
+        name: my-label-value
+    spec:
+      containers:
+        - name: my-container
+          image: nginx:latest
+          resources:
+            limits:
+              cpu: 10m
+`
+
+	objects, err := parseObjects([]byte(okDeployment), nil)
+	require.NoError(t, err)
+	require.Len(t, objects, 1)
+	assert.IsType(t, &appsV1.Deployment{}, objects[0])
+}


### PR DESCRIPTION
…lently

parseObjects() falls back to an unstructured object whenever the typed decoder fails. The fallback exists for custom resources whose Go type KubeLinter does not know, but it also swallowed a manifest of a registered kind that simply is invalid: the workload became an unstructured object, extract.PodTemplateSpec() no longer saw it, and every pod-spec based check silently stopped applying to it. The user was left with an unrelated diagnostic about a different object.

Restrict the fallback to kinds that are not registered in the scheme (runtime.IsNotRegisteredError), so a broken Deployment surfaces as an invalid object while custom resources keep parsing as before.

The invalid objects were then still hidden behind --verbose in the lint command; that gate arrived with a mechanical code move and is dropped, so the load failure and its cause are printed by default.

Fixes #591
Fixes #669