### PR TITLE
fix: resolve ClusterRole refs from RoleBindings

### DIFF
--- a/pkg/templates/accesstoresources/template.go
+++ b/pkg/templates/accesstoresources/template.go
@@ -56,6 +56,9 @@ func init() {
 			return func(lintCtx lintcontext.LintContext, object lintcontext.Object) []diagnostic.Diagnostic {
 				rbinding, ok := object.K8sObject.(*rbacV1.RoleBinding)
 				if ok {
+					if rbinding.RoleRef.Kind == objectkinds.ClusterRole {
+						return findClusterRole(rbinding.RoleRef.Name, lintCtx, resourceRegexes, verbRegexes, p.FlagRolesNotFound)
+					}
 					namespace := stringutils.OrDefault(rbinding.Namespace, "default")
 					return findRole(rbinding.RoleRef.Name, namespace, lintCtx, resourceRegexes, verbRegexes, p.FlagRolesNotFound)
 				}

--- a/pkg/templates/accesstoresources/template_test.go
+++ b/pkg/templates/accesstoresources/template_test.go
@@ -244,6 +244,29 @@ func (s *AccessToSecretsTestSuite) TestClusterRoleWithNoAccessToSecrets() {
 	})
 }
 
+func (s *AccessToSecretsTestSuite) TestRoleBindingReferencesClusterRoleWithAccessToSecrets() {
+	rulesForClusterRole := append([]rbacV1.PolicyRule{}, rules2...)
+	rulesForClusterRole = append(rulesForClusterRole, rules4...)
+	s.addClusterRole(clusterRole1, nil, rulesForClusterRole, aggRule)
+	s.addRoleBinding(roleBinding1, namespace1, clusterRoleRef1, subjects1)
+
+	s.Validate(s.ctx, []templates.TestCase{
+		{
+			Param: params.Params{
+				FlagRolesNotFound: false,
+				Resources:         []string{"^secrets$"},
+				Verbs:             []string{"^get$", "^create$", "^watch$"},
+			},
+			Diagnostics: map[string][]diagnostic.Diagnostic{
+				roleBinding1: {
+					{Message: fmt.Sprintf("binding to %q clusterrole that has [get watch] access to [*]", clusterRole1)},
+				},
+			},
+			ExpectInstantiationError: false,
+		},
+	})
+}
+
 func (s *AccessToSecretsTestSuite) TestClusterRoleWithAggregationRule() {
 	s.addClusterRole(clusterRole1, nil, rules2, aggRule)
 	s.addClusterRole(clusterRole2, labels1, rules4, rbacV1.AggregationRule{})


### PR DESCRIPTION
## Summary

This updates the `access-to-resources` template to follow `roleRef.kind` when a `RoleBinding` references a role.

Kubernetes permits a `RoleBinding` to reference either a `Role` in the same namespace or a cluster-scoped `ClusterRole`. The template currently sends every `RoleBinding` through namespaced `Role` lookup, so the built-in `access-to-secrets` and `access-to-create-pods` checks can miss permissions granted through `RoleBinding -> ClusterRole`.

The change routes a `ClusterRole` reference through the existing cluster-role lookup and adds a focused regression test. Existing `RoleBinding -> Role` and `ClusterRoleBinding -> ClusterRole` behavior is unchanged.

## Reproduction

I reproduced the gap with kube-linter v0.8.3 and current main at `ea3abb8abfe0fc4d7c2b20c9a30d95db9f0b2e2a`:

- `RoleBinding -> ClusterRole` granting `get` on Secrets: no report, exit 0
- equivalent `RoleBinding -> Role`: `access-to-secrets` report, exit 1
- equivalent `ClusterRoleBinding -> ClusterRole`: `access-to-secrets` report, exit 1

The same routing gap also reproduces with `access-to-create-pods` when a `RoleBinding` references a `ClusterRole` granting `create` on Pods.

As an independent role-reference cross-check, public [IaC-Guard-V 0.1.0b1](https://github.com/lokesh0186/iac-guard-v/releases/tag/v0.1.0-beta.1) resolves the fixture's `RoleBinding` to the cluster-scoped `ClusterRole` and reports the binding scope as consistent. IaC-Guard-V does not simulate authorization and is not used here as the `access-to-secrets` oracle.

## Validation

- `go test ./pkg/templates/accesstoresources -count=1`
- `make test`

Both pass with the change.
